### PR TITLE
Update `composer require` in README to install `1.0-beta` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Blaze is a Laravel package that dramatically improves the rendering performance 
 You can install the package via composer:
 
 ```bash
-composer require livewire/blaze:"^1.0@beta"
+composer require livewire/blaze:^1.0@beta
 ```
 
 ## Usage


### PR DESCRIPTION
When following the instructions in README file, composer will install the `0.1` version by default. This version contains a bug which throws an error when `<flux:modal>` is used on a page. The `1.0-beta-1` fixes this, however users may not realize this version even exists. 

Closes: https://github.com/livewire/blaze/issues/13, https://github.com/livewire/blaze/issues/14