### PR TITLE
Fix FileEngine getCompiler() error in viewContainsExpiredFrontMatter

### DIFF
--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -63,7 +63,16 @@ class BlazeManager
             return $this->expiredMemo[$path];
         }
 
-        $compiler = $view->getEngine()->getCompiler();
+        $engine = $view->getEngine();
+
+        // Only CompilerEngine has the getCompiler() method.
+        // FileEngine and PhpEngine do not have this method, so we should skip checking them.
+        if (! method_exists($engine, 'getCompiler')) {
+            $this->expiredMemo[$path] = false;
+            return false;
+        }
+
+        $compiler = $engine->getCompiler();
         $compiled = $compiler->getCompiledPath($path);
         $expired = $compiler->isExpired($path);
 

--- a/tests/FileEngineTest.php
+++ b/tests/FileEngineTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\View\Engines\FileEngine;
+use Illuminate\View\View;
+use Livewire\Blaze\BlazeManager;
+
+describe('FileEngine compatibility', function () {
+    it('handles views with FileEngine gracefully without throwing errors', function () {
+        $blazeManager = app(BlazeManager::class);
+
+        // Create a mock view that uses FileEngine (which doesn't have getCompiler method)
+        $fileEngine = new FileEngine(app('files'));
+
+        // Create a temporary PHP file (not a blade file)
+        $tempPath = sys_get_temp_dir() . '/test-view-' . uniqid() . '.php';
+        file_put_contents($tempPath, '<?php echo "Hello"; ?>');
+
+        try {
+            $view = new View(
+                app('view'),
+                $fileEngine,
+                'test',
+                $tempPath,
+                []
+            );
+
+            // This should not throw an error
+            $result = $blazeManager->viewContainsExpiredFrontMatter($view);
+
+            // For non-compiler engines, it should return false (no expired frontmatter)
+            expect($result)->toBeFalse();
+        } finally {
+            // Clean up
+            @unlink($tempPath);
+        }
+    });
+
+    it('caches the result for FileEngine views', function () {
+        $blazeManager = app(BlazeManager::class);
+
+        $fileEngine = new FileEngine(app('files'));
+
+        $tempPath = sys_get_temp_dir() . '/test-view-cached-' . uniqid() . '.php';
+        file_put_contents($tempPath, '<?php echo "Hello"; ?>');
+
+        try {
+            $view = new View(
+                app('view'),
+                $fileEngine,
+                'test',
+                $tempPath,
+                []
+            );
+
+            // First call
+            $result1 = $blazeManager->viewContainsExpiredFrontMatter($view);
+
+            // Second call (should use cached result)
+            $result2 = $blazeManager->viewContainsExpiredFrontMatter($view);
+
+            expect($result1)->toBeFalse();
+            expect($result2)->toBeFalse();
+            expect($result1)->toBe($result2);
+        } finally {
+            @unlink($tempPath);
+        }
+    });
+
+    it('still works correctly with CompilerEngine (blade views)', function () {
+        // This ensures our fix doesn't break the normal blade compilation flow
+        $blazeManager = app(BlazeManager::class);
+
+        // Set up blade compiler
+        app('blade.compiler')->anonymousComponentPath(__DIR__ . '/fixtures/components');
+
+        // Create a blade view
+        $template = '<x-button>Click me</x-button>';
+        $compiled = $blazeManager->compile($template);
+
+        expect($compiled)->toBeString();
+        expect($compiled)->toContain('button');
+    });
+});


### PR DESCRIPTION
## Description

This PR fixes the `Call to undefined method Illuminate\View\Engines\FileEngine::getCompiler()` error that occurs when Blaze processes views using non-compiler engines.

Fixes #12

## Problem

The `viewContainsExpiredFrontMatter()` method assumes all view engines have a `getCompiler()` method, but Laravel has multiple view engines:

- ✅ **CompilerEngine** - Has `getCompiler()` (used for `.blade.php` files)
- ❌ **FileEngine** - Does NOT have `getCompiler()` (used for plain `.php` files)
- ❌ **PhpEngine** - Does NOT have `getCompiler()`

This causes errors when:
- Email notifications are sent (especially in queued jobs)
- Plain PHP views are rendered
- Any view using FileEngine or PhpEngine is processed

## Solution

Added a `method_exists()` check before calling `getCompiler()`. For engines without a compiler, it returns `false` (no expired frontmatter).

```php
$engine = $view->getEngine();

// Only CompilerEngine has the getCompiler() method.
// FileEngine and PhpEngine do not have this method, so we should skip checking them.
if (! method_exists($engine, 'getCompiler')) {
    $this->expiredMemo[$path] = false;
    return false;
}
```

This is correct because non-compiler engines don't compile templates, so they can't have expired frontmatter.

## Why This Approach?

Unlike PR #15 which always checks the Blade compiler regardless of the view's actual engine, this fix:
1. Respects the actual engine being used by the view
2. Correctly handles engines that don't have compilers
3. Is more explicit about why we're skipping the check
4. Doesn't bypass Laravel's view engine architecture
5. Properly caches results to avoid repeated checks

## Tests

Added comprehensive test coverage in `tests/FileEngineTest.php`:
- ✅ Handles FileEngine views without errors
- ✅ Caches results for FileEngine views
- ✅ Still works correctly with CompilerEngine (Blade views)

All 141 tests pass (138 existing + 3 new).

## Tested On

- PHP 8.2.28
- Laravel 12.0
- Livewire Blaze (latest main branch)
- Real-world scenario: Queued email notifications with inline images
