### PR TITLE
Move macro registration from `register()` to `boot()`

### DIFF
--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -17,7 +17,6 @@ class BlazeServiceProvider extends ServiceProvider
     {
         $this->registerBlazeManager();
         $this->registerBlazeDirectiveFallbacks();
-        $this->registerBladeMacros();
         $this->interceptBladeCompilation();
         $this->interceptViewCacheInvalidation();
     }
@@ -104,6 +103,6 @@ class BlazeServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        // Bootstrap services
+        $this->registerBladeMacros();
     }
 }


### PR DESCRIPTION
Fixes icon component registration issue when using Blaze with  `blade-ui-kit/blade-icons` and potential race conditional related to registration with children packages like `mallardduck/blade-lucide-icons`.

## The Problem
`BlazeServiceProvider::register()` calls `$this->app->make('view')` to register macros, which resolves the `ViewFactory` before potentially all icon packages have registered their icon sets. This breaks packages that use `callAfterResolving(ViewFactory, callback)`.

## The Fix
Move macro registration from `register()` to `boot()`. This ensures all service providers complete their `register()` phase before ViewFactory is resolved.

## Related
- #18 