### PR TITLE
Prevent blade comments from being parsed

### DIFF
--- a/src/BladeService.php
+++ b/src/BladeService.php
@@ -96,6 +96,17 @@ class BladeService
         return $storeVerbatimBlocks->invoke($compiler, $input);
     }
 
+    public function preCompileComments(string $input): string
+    {
+        $compiler = app('blade.compiler');
+
+        $reflection = new \ReflectionClass($compiler);
+        $storeVerbatimBlocks = $reflection->getMethod('compileComments');
+        $storeVerbatimBlocks->setAccessible(true);
+
+        return $storeVerbatimBlocks->invoke($compiler, $input);
+    }
+
     public function viewCacheInvalidationHook(callable $callback)
     {
         Event::listen('composing:*', function ($event, $params) use ($callback) {

--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -83,7 +83,9 @@ class BlazeManager
     public function compile(string $template): string
     {
         // Protect verbatim and php blocks before tokenization
-        $template = (new BladeService)->preStoreUncompiledBlocks($template);
+        $blade = new BladeService;
+        $template = $blade->preStoreUncompiledBlocks($template);
+        $template = $blade->preCompileComments($template);
 
         $tokens = $this->tokenizer->tokenize($template);
 

--- a/tests/FoldTest.php
+++ b/tests/FoldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Blade;
+
 describe('fold elligable components', function () {
     beforeEach(function () {
         app('blade.compiler')->anonymousComponentPath(__DIR__ . '/fixtures/components');
@@ -199,7 +201,7 @@ describe('fold elligable components', function () {
         $output = '<div class="group group-primary" data-test="foo"><div class="item item-primary"></div></div>';
 
         $compiled = compile($input);
-        $rendered = \Illuminate\Support\Facades\Blade::render($compiled);
+        $rendered = Blade::render($compiled);
 
         expect($rendered)->toBe($output);
     });
@@ -210,7 +212,7 @@ describe('fold elligable components', function () {
         $output = '<div class="group group-primary" data-test="foo" data-second-variant="secondary"><div class="item item-primary item-secondary"></div></div>';
 
         $compiled = compile($input);
-        $rendered = \Illuminate\Support\Facades\Blade::render($compiled);
+        $rendered = Blade::render($compiled);
 
         expect($rendered)->toBe($output);
     });
@@ -221,7 +223,7 @@ describe('fold elligable components', function () {
         $output = '<div class="group group-primary" data-test="bar"><div class="item item-primary"></div></div>';
 
         $compiled = compile($input);
-        $rendered = \Illuminate\Support\Facades\Blade::render($compiled);
+        $rendered = Blade::render($compiled);
 
         expect($rendered)->toBe($output);
     });
@@ -242,7 +244,7 @@ BLADE;
 
 BLADE;
 
-        $rendered = \Illuminate\Support\Facades\Blade::render($input);
+        $rendered = Blade::render($input);
 
         expect($rendered)->toBe($output);
     });
@@ -254,11 +256,28 @@ echo '<x-card>';
 @endphp
 BLADE;
 
-        $rendered = \Illuminate\Support\Facades\Blade::render($input);
+        $rendered = Blade::render($input);
 
         // The <x-card> in php block should not be rendered...
         expect($rendered)->toContain('<x-card>');
     });
+
+    it('supports comments', function () {
+        $input = '{{-- <x-card> --}}';
+        
+        $renderedCard = false;
+
+        Blade::prepareStringsForCompilationUsing(function ($template) use (&$renderedCard) {
+            if (str_contains($template, 'class="card"')) {
+                $renderedCard = true;
+            }
+        });
+
+        Blade::render($input);
+
+        expect($renderedCard)->toBeFalse();
+    });
+
 
     it('can fold static props that get formatted', function () {
         $input = '<x-date date="2025-07-11 13:22:41 UTC" />';


### PR DESCRIPTION
# The problem

Currently Blaze parses Blade comments:

```blade
{{-- <x-card> --}}
```

Even though the comment will be later removed by Blade, Blaze still parsed and rendered the card component in the background.

# The solution

The solution is to use Blade's `compileComments` method to remove all comments before they're parsed.