### PR TITLE
Remove `setAccessible` calls

### DIFF
--- a/src/BladeService.php
+++ b/src/BladeService.php
@@ -91,7 +91,6 @@ class BladeService
 
         $reflection = new \ReflectionClass($compiler);
         $storeVerbatimBlocks = $reflection->getMethod('storeUncompiledBlocks');
-        $storeVerbatimBlocks->setAccessible(true);
 
         return $storeVerbatimBlocks->invoke($compiler, $input);
     }
@@ -102,7 +101,6 @@ class BladeService
 
         $reflection = new \ReflectionClass($compiler);
         $storeVerbatimBlocks = $reflection->getMethod('compileComments');
-        $storeVerbatimBlocks->setAccessible(true);
 
         return $storeVerbatimBlocks->invoke($compiler, $input);
     }
@@ -129,7 +127,6 @@ class BladeService
 
         $reflection = new \ReflectionClass($compiler);
         $pathsProperty = $reflection->getProperty('anonymousComponentPaths');
-        $pathsProperty->setAccessible(true);
         $paths = $pathsProperty->getValue($compiler) ?? [];
 
         // Handle namespaced components...
@@ -224,8 +221,6 @@ class BladeService
 
             $property = $reflection->getProperty($name);
 
-            $property->setAccessible(true);
-
             $frozen[$name] = $property->getValue($object);
 
             if (! is_numeric($key)) {
@@ -238,7 +233,6 @@ class BladeService
             function () use ($reflection, $object, $frozen) {
                 foreach ($frozen as $name => $value) {
                     $property = $reflection->getProperty($name);
-                    $property->setAccessible(true);
                     $property->setValue($object, $value);
                 }
             },


### PR DESCRIPTION
https://www.php.net/manual/en/reflectionmethod.setaccessible.php

> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

Blaze requires at least PHP 8.2.