### PR TITLE
Fix infinite loop caused by null directive callback return

### DIFF
--- a/src/Support/Directives.php
+++ b/src/Support/Directives.php
@@ -25,6 +25,8 @@ class Directives
         
         BladeService::compileDirective($this->content, $name, function () use (&$result) {
             $result = true;
+
+            return '';
         });
         
         return $result;
@@ -39,6 +41,8 @@ class Directives
 
         BladeService::compileDirective($this->content, $name, function ($expression) use (&$result) {
             $result = $expression;
+
+            return '';
         });
         
         return $result;


### PR DESCRIPTION
## Summary

- The callbacks in `Directives::get()` and `Directives::has()` had no return statement, implicitly returning `null`
- This `null` propagated through `BladeCompiler::compileStatements()` → `replaceFirstStatement()`, where `strlen(null)` evaluated to `0`, preventing the offset from advancing — causing an infinite loop during view compilation
- Fixed by adding `return '';` to both callbacks

## Test plan

- [x] Confirmed site hangs indefinitely on first load after `php artisan view:clear` without fix
- [x] Confirmed site loads in ~0.5s with fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)