### PR TITLE
Fix service provider

### DIFF
--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -9,21 +9,7 @@ use Illuminate\Support\Facades\View;
 
 class BlazeServiceProvider extends ServiceProvider
 {
-    /** {@inheritdoc} */
     public function register(): void
-    {
-        $this->registerBlazeManager();
-        $this->registerBlazeRuntime();
-        $this->registerBlazeDirectives();
-        $this->registerBladeMacros();
-        $this->interceptBladeCompilation();
-        $this->interceptViewCacheInvalidation();
-    }
-
-    /**
-     * Register the BlazeManager singleton and its aliases.
-     */
-    protected function registerBlazeManager(): void
     {
         $this->app->singleton(BlazeRuntime::class);
         $this->app->singleton(Config::class);
@@ -36,6 +22,15 @@ class BlazeServiceProvider extends ServiceProvider
         $this->app->alias(BlazeRuntime::class, 'blaze.runtime');
         $this->app->alias(Config::class, 'blaze.config');
         $this->app->alias(Debugger::class, 'blaze.debugger');
+    }
+
+    public function boot(): void
+    {
+        $this->registerBlazeDirectives();
+        $this->registerBlazeRuntime();
+        $this->registerBladeMacros();
+        $this->interceptViewCacheInvalidation();
+        $this->interceptBladeCompilation();
     }
 
     /**
@@ -118,11 +113,5 @@ class BlazeServiceProvider extends ServiceProvider
                 $invalidate();
             }
         });
-    }
-
-    /** {@inheritdoc} */
-    public function boot(): void
-    {
-        //
     }
 }


### PR DESCRIPTION
## The scenario

Installing Blaze alongside packages that register Blade components (e.g., `blade-lucide-icons`) breaks component resolution.

## The problem

The service provider was performing all of its setup in `register()`. This prematurely resolved the view factory, causing Blade UI Icons to register its components before icon set libraries could add their presets.

The exact sequence during the `register()` phase:

1. **`BladeIconsServiceProvider::register()`** — sets up an "after resolving" callback on the view factory. When fired, it registers all known icon sets as Blade components.
2. **`BlazeServiceProvider::register()`** — resolves the view factory for the first time via `View::macro()`. This fires the callback from step 1, but only the icon sets registered so far are present.
3. **`BladeLucideIconsServiceProvider::register()`** — adds the lucide icon set. But the Blade components were already registered in step 2 and won't be registered again. The lucide icons are never registered as Blade components.

The result: `<x-lucide-activity />` throws an "Unable to locate view" error.

## The solution

Moved everything except container bindings from `register()` to `boot()`.

This is also the correct Laravel convention — resolving other services should happen in `boot()`, not `register()`, precisely to avoid this class of ordering bugs.

Fixes livewire/blaze#18