### PR TITLE
Detect livewire

### DIFF
--- a/tests/Compiler/WrapperTest.php
+++ b/tests/Compiler/WrapperTest.php
@@ -29,20 +29,13 @@ test('wraps component templates into function definitions', function () {
     ]));
 });
 
-test('injects errors when source uses dollar sign errors', function () {
-    $path = fixture_path('components/compilable/input-errors.blade.php');
-    $source = file_get_contents($path);
-
-    $wrapped = app(Wrapper::class)->wrap($source, $path, $source);
-
-    expect($wrapped)->toContain('$errors = $__blaze->errors;');
-});
-
-test('injects errors when source uses errors directive', function () {
-    $path = fixture_path('components/compilable/input-errors-directive.blade.php');
-    $source = file_get_contents($path);
-
-    $wrapped = app(Wrapper::class)->wrap($source, $path, $source);
-
-    expect($wrapped)->toContain('$errors = $__blaze->errors;');
-});
+test('injects variables', function ($source, $expected) {
+    expect(app(Wrapper::class)->wrap('', '', $source))->toContain($expected);
+    expect(app(Wrapper::class)->wrap($source, '', ''))->toContain($expected);
+})->with([
+    'errors' => ['{{ $errors->has(\'name\') }}', '$errors = $__blaze->errors;'],
+    'errors directive' => ['<input @error(\'name\') invalid @enderror >', '$errors = $__blaze->errors;'],
+    'livewire' => ['{{ $__livewire->id }}', '$__livewire = $__env->shared(\'__livewire\');'],
+    'entangle' => ['<div x-data="{ name: @entangle(\'name\') }"></div>', '$__livewire = $__env->shared(\'__livewire\');'],
+    'app' => ['{{ $app->name }}', '$app = $__blaze->app;'],
+]);

--- a/tests/fixtures/components/compilable/input-errors-directive.blade.php
+++ b/tests/fixtures/components/compilable/input-errors-directive.blade.php
@@ -1,1 +1,0 @@
-<input @error('name') invalid @enderror >

--- a/tests/fixtures/components/compilable/input-errors.blade.php
+++ b/tests/fixtures/components/compilable/input-errors.blade.php
@@ -1,1 +1,0 @@
-<input @if ($errors->has('name')) invalid @endif >


### PR DESCRIPTION
# The scenario

Using Livewire features like `$__livewire` or `@entangle` inside compiled Blaze components.

```blade
<div x-data="{ name: @entangle('name') }"></div>
```

which compiles to

```blade
<div x-data="{ name: Livewire.find('{{ \$__livewire->getId() }}').entangle('name') }"></div>
```

# The problem

The wrapper doesn't detect or inject `$__livewire`, so components using `@entangle` or `$__livewire` fail at runtime.

# The solution

Detect `$__livewire` and `@entangle` in source/compiled output and inject:

```php
$__livewire = $__env->shared('__livewire');
```