### PR TITLE
Fix attribute parser

### DIFF
--- a/src/Parser/Nodes/ComponentNode.php
+++ b/src/Parser/Nodes/ComponentNode.php
@@ -12,9 +12,6 @@ use Livewire\Blaze\Parser\Attribute;
  */
 class ComponentNode extends Node
 {
-    /** @var Attribute[] */
-    public array $attributes = [];
-
     /** Pre-computed by the Walker before children are compiled to TextNodes. */
     public bool $hasAwareDescendants = false;
 
@@ -25,18 +22,22 @@ class ComponentNode extends Node
         public array $children = [],
         public bool $selfClosing = false,
         public array $parentsAttributes = [],
+        /** @var Attribute[] */
+        public array $attributes = [],
     ) {
-        $attributes = Utils::parseAttributeStringToArray($this->attributeString);
+        if (empty($this->attributes) && ! empty($this->attributeString)) {
+            $attributes = Utils::parseAttributeStringToArray($this->attributeString);
 
-        foreach ($attributes as $key => $attribute) {
-            $this->attributes[$key] = new Attribute(
-                name: $attribute['name'],
-                value: $attribute['value'],
-                propName: $key,
-                dynamic: $attribute['isDynamic'] || str_contains($attribute['original'], '{{'),
-                prefix: Str::match('/^(::|\:\$|:)/', $attribute['original']),
-                quotes: $attribute['quotes'],
-            );
+            foreach ($attributes as $key => $attribute) {
+                $this->attributes[$key] = new Attribute(
+                    name: $attribute['name'],
+                    value: $attribute['value'],
+                    propName: $key,
+                    dynamic: $attribute['isDynamic'] || str_contains($attribute['original'], '{{'),
+                    prefix: Str::match('/^(::|\:\$|:)/', $attribute['original']),
+                    quotes: $attribute['quotes'],
+                );
+            }
         }
     }
 

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -344,6 +344,15 @@ class Tokenizer
         while (!$this->isAtEnd()) {
             $char = $this->current();
 
+            // Skip over Blade echo expressions ({{ }} and {!! !!}) without
+            // updating quote state — quotes inside Blade tags are PHP-level
+            // and must not interfere with HTML attribute boundary detection.
+            if ($char === '{' && ($bladeExpr = $this->consumeBladeExpression())) {
+                $attrString .= $bladeExpr;
+
+                continue;
+            }
+
             $prevChar = $this->position > 0 ? $this->content[$this->position - 1] : '';
 
             if ($char === '"' && !$inSingleQuote && $prevChar !== '\\') {
@@ -393,6 +402,47 @@ class Tokenizer
         if ($attrString !== '') {
             $this->currentToken->attributes[] = $attrString;
         }
+    }
+
+    /**
+     * If the current position is at a Blade echo expression ({{ or {!!),
+     * consume the entire expression and return it. Returns null otherwise.
+     */
+    protected function consumeBladeExpression(): ?string
+    {
+        if ($this->matchesAt('{!!')) {
+            return $this->consumeUntil('{!!', '!!}');
+        }
+
+        if ($this->matchesAt('{{')) {
+            return $this->consumeUntil('{{', '}}');
+        }
+
+        return null;
+    }
+
+    /**
+     * Consume content from the opening delimiter through the closing delimiter,
+     * advancing the position past the entire expression.
+     */
+    protected function consumeUntil(string $open, string $close): string
+    {
+        $start = $this->position;
+
+        $this->advance(strlen($open));
+
+        while (!$this->isAtEnd()) {
+            if ($this->matchesAt($close)) {
+                $this->advance(strlen($close));
+
+                return substr($this->content, $start, $this->position - $start);
+            }
+
+            $this->advance();
+        }
+
+        // Unclosed expression — return what we have.
+        return substr($this->content, $start, $this->position - $start);
     }
 
     /**

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -4,6 +4,7 @@ use Livewire\Blaze\Parser\Parser;
 use Livewire\Blaze\Parser\Nodes\ComponentNode;
 use Livewire\Blaze\Parser\Nodes\SlotNode;
 use Livewire\Blaze\Parser\Nodes\TextNode;
+use Livewire\Blaze\Parser\Attribute;
 
 test('parses self-closing components', function () {
     $input = '<x-button class="my-4" />';
@@ -127,3 +128,26 @@ test('handles attributes with angled brackets', function ($attributes) {
     'array' => [':data="[\'foo\' => \'bar\']"'],
     'lambda' => [':callback="fn () => 0"'],
 ]);
+
+test('handles attributes with quotes inside echos', function () {
+    $input = '<x-button x-text="\'{{ __("Print") }}\'" />';
+
+    expect(app(Parser::class)->parse($input))->toEqual([
+        new ComponentNode(
+            name: 'button',
+            prefix: 'x-',
+            attributeString: 'x-text="\'{{ __("Print") }}\'"',
+            selfClosing: true,
+            attributes: [
+                'xText' => new Attribute(
+                    name: 'x-text',
+                    value: '\'{{ __("Print") }}\'',
+                    propName: 'xText',
+                    dynamic: true,
+                    prefix: '',
+                    quotes: '"',
+                ),
+            ],
+        ),
+    ]);
+});


### PR DESCRIPTION
# The scenario

Quotes inside Blade echo expressions break attribute parsing:

```blade
<x-button x-text="'{{ __("Print") }}'" />
```

# The problem

Both the Tokenizer and the AttributeParser use quote tracking to determine attribute boundaries.

The quotes inside `{{ }}` toggle the quote state mid-value:

```
x-text="'{{ __("Print") }}'"
       ^       ^
```

The parser thinks the quoted string ended early, breaking the attribute in half.

# The solution

Treat Blade echo expressions (`{{ }}` and `{!! !!}`) as opaque tokens in both places:

- **Tokenizer::collectAttributes()** — consume entire expressions without updating quote state.
- **AttributeParser::parseAttributeStringToArray()** — shield expressions with placeholders before regex parsing.