### PR TITLE
Fix parsing of component tags with underscores

### DIFF
--- a/src/Support/LaravelRegex.php
+++ b/src/Support/LaravelRegex.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Livewire\Blaze\Support;
+
+/**
+ * Regex patterns sourced from Laravel's ComponentTagCompiler.
+ *
+ * Every constant in this class MUST match the corresponding regex
+ * in Laravel's source exactly. Do not modify these without first
+ * verifying the change against the Laravel source cited in each
+ * constant's docblock.
+ *
+ * @see vendor/laravel/framework/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+ */
+class LaravelRegex
+{
+    /**
+     * Pattern for matching a component tag name at the current position.
+     *
+     * @see ComponentTagCompiler::compileOpeningTags()     — x[-\:]([\w\-\:\.]*)
+     * @see ComponentTagCompiler::compileSelfClosingTags() — x[-\:]([\w\-\:\.]*)
+     * @see ComponentTagCompiler::compileClosingTags()     — x[-\:][\w\-\:\.]*
+     */
+    const TAG_NAME = '/^[\w\-\:\.]*/';
+
+    /**
+     * Pattern for matching a slot inline name (e.g., <x-slot:header>).
+     *
+     * @see ComponentTagCompiler::compileSlots() — (\w+(?:-\w+)*)
+     */
+    const SLOT_INLINE_NAME = '/^\w+(?:-\w+)*/';
+}


### PR DESCRIPTION
# The scenario

Components with underscores in their tag names are not parsed correctly by Blaze:

```html
<x-my_component />
```

# The problem

Our tag name and slot name regexes don't match Laravel's `ComponentTagCompiler`.

Ours:
```php
// tag name
'/^[a-zA-Z0-9-\.:]+/'
// slot name
'/^[a-zA-Z0-9-]+/'
```

Laravel's:
```php
// tag name
'[\w\-\:\.]*'
// slot name
'\w+(?:-\w+)*'
```

`\w` includes underscores (and is Unicode-aware), `[a-zA-Z0-9]` doesn't.

# The solution

Introduced `LaravelRegex` — a class for regex patterns sourced from Laravel's `ComponentTagCompiler`:

```php
/**
 * ...every constant in this class MUST match the corresponding regex
 * in Laravel's source exactly. Do not modify these without first
 * verifying the change against Laravel...
 */
class LaravelRegex
{
    /**
     * @see ComponentTagCompiler::compileOpeningTags()     — x[-\:]([\w\-\:\.]*)
     * @see ComponentTagCompiler::compileSelfClosingTags() — x[-\:]([\w\-\:\.]*)
     * @see ComponentTagCompiler::compileClosingTags()     — x[-\:][\w\-\:\.]*
     */
    const TAG_NAME = '/^[\w\-\:\.]*/';
}
```

```php
if (preg_match(LaravelRegex::TAG_NAME, $this->remaining(), $matches)) {
    return $matches[0];
}
```

This avoids having to test every permutation of valid tag and slot names — we're relying on Laravel's behavior directly.

Any future change requires confronting the Laravel source references.