### PR TITLE
Improve attribute parser

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -124,7 +124,7 @@ class Compiler
     protected function compileDelegateComponentTag(ComponentNode $node): string
     {
         $attributesArray = Utils::parseAttributeStringToArray($node->attributeString);
-        $componentName = "'flux::' . " . $attributesArray['component']['value'];
+        $componentName = "'flux::' . " . $attributesArray['component']->value;
 
         $output = '<' . '?php $__resolved = $__blaze->resolve(' . $componentName . '); ?>' . "\n";
         $output .= '<' . '?php require_once $__blaze->compiledPath . \'/\' . $__resolved . \'.php\'; ?>' . "\n";

--- a/src/Parser/Nodes/ComponentNode.php
+++ b/src/Parser/Nodes/ComponentNode.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Blaze\Parser\Nodes;
 
-use Illuminate\Support\Str;
 use Livewire\Blaze\Support\AttributeParser;
 use Livewire\Blaze\Support\Utils;
 use Livewire\Blaze\Parser\Attribute;
@@ -26,18 +25,7 @@ class ComponentNode extends Node
         public array $attributes = [],
     ) {
         if (empty($this->attributes) && ! empty($this->attributeString)) {
-            $attributes = Utils::parseAttributeStringToArray($this->attributeString);
-
-            foreach ($attributes as $key => $attribute) {
-                $this->attributes[$key] = new Attribute(
-                    name: $attribute['name'],
-                    value: $attribute['value'],
-                    propName: $key,
-                    dynamic: $attribute['isDynamic'] || str_contains($attribute['original'], '{{'),
-                    prefix: Str::match('/^(::|\:\$|:)/', $attribute['original']),
-                    quotes: $attribute['quotes'],
-                );
-            }
+            $this->attributes = Utils::parseAttributeStringToArray($this->attributeString);
         }
     }
 

--- a/src/Parser/Nodes/SlotNode.php
+++ b/src/Parser/Nodes/SlotNode.php
@@ -21,18 +21,7 @@ class SlotNode extends Node
         public string $prefix = 'x-slot',
         public bool $closeHasName = false,
     ) {
-        $attributes = Utils::parseAttributeStringToArray($this->attributeString);
-
-        foreach ($attributes as $key => $attribute) {
-            $this->attributes[$key] = new Attribute(
-                name: $attribute['name'],
-                value: $attribute['value'],
-                propName: $key,
-                dynamic: $attribute['isDynamic'] || str_contains($attribute['original'], '{{'),
-                prefix: \Illuminate\Support\Str::match('/^(:\$?)/', $attribute['original']),
-                quotes: $attribute['quotes'],
-            );
-        }
+        $this->attributes = Utils::parseAttributeStringToArray($this->attributeString);
     }
 
     /** {@inheritdoc} */

--- a/src/Support/LaravelRegex.php
+++ b/src/Support/LaravelRegex.php
@@ -29,4 +29,25 @@ class LaravelRegex
      * @see ComponentTagCompiler::compileSlots() — (\w+(?:-\w+)*)
      */
     const SLOT_INLINE_NAME = '/^\w+(?:-\w+)*/';
+
+    /**
+     * Full pattern for matching individual attributes after preprocessing.
+     *
+     * @see ComponentTagCompiler::getAttributesFromAttributeString() — line 605
+     */
+    const ATTRIBUTE_PATTERN = '/
+        (?<attribute>[\w\-:.@%]+)
+        (
+            =
+            (?<value>
+                (
+                    \"[^\"]+\"
+                    |
+                    \\\'[^\\\']+\\\'
+                    |
+                    [^\s>]+
+                )
+            )
+        )?
+    /x';
 }

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -4,6 +4,7 @@ namespace Livewire\Blaze\Support;
 
 use Livewire\Blaze\BladeService;
 use Livewire\Blaze\Directive\BlazeDirective;
+use Livewire\Blaze\Parser\Attribute;
 
 /**
  * Static utility helpers used across the Blaze pipeline.
@@ -35,7 +36,9 @@ class Utils
     }
 
     /**
-     * Parse an attribute string into a structured array.
+     * Parse an attribute string into a keyed array of Attribute objects.
+     *
+     * @return array<string, Attribute>
      */
     public static function parseAttributeStringToArray(string $attributeString): array
     {

--- a/tests/Support/AttributeParserTest.php
+++ b/tests/Support/AttributeParserTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Livewire\Blaze\Support\AttributeParser;
+
+test('parses bound attributes', function () {
+    $attrs = (new AttributeParser)->parseAttributeStringToArray(':foo="bar"');
+
+    expect($attrs)->toHaveKey('foo');
+    expect($attrs['foo'])
+        ->name->toBe('foo')
+        ->value->toBe('bar')
+        ->prefix->toBe(':')
+        ->dynamic->toBeTrue();
+});
+
+test('parses escaped bound attributes', function () {
+    $attrs = (new AttributeParser)->parseAttributeStringToArray('::key="value"');
+
+    expect($attrs)->toHaveKey(':key');
+    expect($attrs[':key'])
+        ->name->toBe(':key')
+        ->value->toBe('value')
+        ->prefix->toBe('::')
+        ->dynamic->toBeFalse();
+});
+
+test('parses attributes without value', function () {
+    $attrs = (new AttributeParser)->parseAttributeStringToArray('disabled');
+
+    expect($attrs)->toHaveKey('disabled');
+    expect($attrs['disabled'])
+        ->name->toBe('disabled')
+        ->value->toBeTrue()
+        ->dynamic->toBeFalse()
+        ->quotes->toBe('');
+});
+
+test('parses attributes with blade echo', function () {
+    $attrs = (new AttributeParser)->parseAttributeStringToArray('title="{{ $x }}"');
+
+    expect($attrs)->toHaveKey('title');
+    expect($attrs['title'])
+        ->name->toBe('title')
+        ->value->toBe('{{ $x }}')
+        ->dynamic->toBeTrue();
+});
+
+
+test('parses quotes', function () {
+    $attrs = (new AttributeParser)->parseAttributeStringToArray('double="hello" single=\'hello\'');
+
+    expect($attrs['double']->quotes)->toBe('"');
+    expect($attrs['single']->quotes)->toBe("'");
+});
+
+test('parses kebab case attributes', function () {
+    $attrs = (new AttributeParser)->parseAttributeStringToArray('foo-bar="first"');
+
+    expect($attrs)->toHaveKey('fooBar');
+    expect($attrs['fooBar'])
+        ->name->toBe('foo-bar')
+        ->propName->toBe('fooBar');
+});
+
+test('keeps first attribute when multiple camelize to same key', function () {
+    $attrs = (new AttributeParser)->parseAttributeStringToArray('foo-bar="first" foo_bar="second"');
+
+    expect($attrs)->toHaveCount(1)->toHaveKey('fooBar');
+    expect($attrs['fooBar']->value)->toBe('first');
+});


### PR DESCRIPTION
# The scenario

These syntaxes were broken:

```blade
{{-- JavaScript inside attribute values produced ghost attributes --}}
<flux:menu.item x-data="{
    init() {
        this.document.title = '{{ $title }}';
    }
}">

{{-- @ attributes silently dropped --}}
<x-button @click="handle" />
```

# The problem

The old `AttributeParser` used hand-rolled regexes that were buggy and inconsistent with Laravel.

* We would match `this.document.title = '{{ ... }}'` *inside* the x-data JavaScript as a separate attribute.
* Attributes with `@` symbols were silently dropped because the old regex didn't include `@`.

# The solution

Replace the old attribute parsing with Laravel's own approach from `ComponentTagCompiler::getAttributesFromAttributeString()`:

1. Run Laravel's full preprocessing pipeline on attribute strings before parsing, to avoid further drift.
2. Use Laravel's attribute regex, added as `LaravelRegex::ATTRIBUTE_PATTERN`:

```php
const ATTRIBUTE_PATTERN = '/
    (?<attribute>[\w\-:.@%]+)
    (=(?<value>("[^"]+"|\'[^\']+\'|[^\s>]+)))?
/x';
```