### PR TITLE
Add Blade fallback for delegate components

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -127,13 +127,15 @@ class Compiler
         $componentName = "'flux::' . " . $attributesArray['component']->value;
 
         $output = '<' . '?php $__resolved = $__blaze->resolve(' . $componentName . '); ?>' . "\n";
-        $output .= '<' . '?php require_once $__blaze->compiledPath . \'/\' . $__resolved . \'.php\'; ?>' . "\n";
-
-        $output .= '<' . '?php $__blaze->pushData($attributes->all()); ?>';
 
         $slotsVariableName = '$slots' . hash('xxh128', $componentName);
 
         $functionName = '(\'' . (Blaze::isFolding() ? '__' : '_') . '\' . $__resolved)';
+
+        $output .= '<' . '?php $__blaze->pushData($attributes->all()); ?>';
+
+        $output .= "\n" . '<' . '?php if ($__resolved !== false): ?>';
+        $output .= "\n" . '<' . '?php require_once $__blaze->compiledPath . \'/\' . $__resolved . \'.php\'; ?>';
 
         if ($node->selfClosing) {
             $output .= "\n" . '<' . '?php ' . $functionName . '($__blaze, $attributes->all(), $__blaze->mergedComponentSlots(), [], isset($this) ? $this : null); ?>';
@@ -142,6 +144,10 @@ class Compiler
             $output .= "\n" . '<' . '?php ' . $slotsVariableName . ' = array_merge($__blaze->mergedComponentSlots(), ' . $slotsVariableName . '); ?>';
             $output .= "\n" . '<' . '?php ' . $functionName . '($__blaze, $attributes->all(), ' . $slotsVariableName . ', [], isset($this) ? $this : null); ?>';
         }
+
+        $output .= "\n" . '<' . '?php else: ?>';
+        $output .= "\n" . $node->render();
+        $output .= "\n" . '<' . '?php endif; ?>';
 
         $output .= "\n" . '<' . '?php $__blaze->popData(); ?>';
         $output .= "\n" . '<' . '?php unset($__resolved) ?>' . "\n";

--- a/tests/Compiler/CompilerTest.php
+++ b/tests/Compiler/CompilerTest.php
@@ -65,9 +65,13 @@ test('compiles delegate components', function () {
 
     expect($compiled->render())->toEqualCollapsingWhitespace(join('', [
         '<?php $__resolved = $__blaze->resolve(\'flux::\' . card); ?> ',
-        '<?php require_once $__blaze->compiledPath . \'/\' . $__resolved . \'.php\'; ?> ',
         '<?php $__blaze->pushData($attributes->all()); ?> ',
+        '<?php if ($__resolved !== false): ?> ',
+        '<?php require_once $__blaze->compiledPath . \'/\' . $__resolved . \'.php\'; ?> ',
         '<?php (\'_\' . $__resolved)($__blaze, $attributes->all(), $__blaze->mergedComponentSlots(), [], isset($this) ? $this : null); ?> ',
+        '<?php else: ?> ',
+        '<flux:delegate-component component="card" /> ',
+        '<?php endif; ?> ',
         '<?php $__blaze->popData(); ?> ',
         '<?php unset($__resolved) ?> ',
     ]));


### PR DESCRIPTION
# The scenario

A user has Blaze installed and uses a custom Flux icon or variant:

```blade
<flux:icon name="custom" />
```

Where "custom" is a Blade view in `resources/views/flux/icon/custom.blade.php` without a `@blaze` directive.

# The problem

The icon component uses `flux::delegate-component` and Blaze assumes all delegate targets are optimized.

But the custom icon template doesn't have `@blaze`, therefore it's not compiled into a function.

Resulting in an exception:

```
Call to undefined function _eab27ebdf4ee954a9a05ceed5425e512()
```

# The solution

Instead of forcing all custom components to be blaze-compiled (livewire/flux#2411), we check at runtime whether the delegate target is a Blaze component. If not, we skip Blaze entirely and fall back to standard Blade rendering.

Custom components without `@blaze` just work — no configuration needed, no forced compilation.

Replaces livewire/flux#2411.