### PR TITLE
Add BLAZE_ENABLED and BLAZE_DEBUG env config

### DIFF
--- a/config/blaze.php
+++ b/config/blaze.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable Blaze
+    |--------------------------------------------------------------------------
+    |
+    | When set to false, Blaze will skip all compilation and optimization.
+    | Templates will be rendered using standard Blade without any Blaze
+    | processing. This is useful for debugging or disabling Blaze in
+    | specific environments.
+    |
+    */
+
+    'enabled' => env('BLAZE_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Debug Mode
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, Blaze will register the debugger middleware and output
+    | additional diagnostic information about the compilation pipeline.
+    |
+    */
+
+    'debug' => env('BLAZE_DEBUG', false),
+
+];

--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -20,9 +20,9 @@ use Livewire\Blaze\Parser\Nodes\SlotNode;
 
 class BlazeManager
 {
-    protected $enabled = true;
+    protected $enabled;
     protected $throw = false;
-    protected $debug = false;
+    protected $debug;
     protected $folding = false;
     
     protected $foldedEvents = [];
@@ -38,6 +38,13 @@ class BlazeManager
         protected Wrapper $wrapper,
         protected Config $config,
     ) {
+        $this->enabled = config('blaze.enabled', true);
+        $this->debug = config('blaze.debug', false);
+
+        if ($this->debug) {
+            DebuggerMiddleware::register();
+        }
+
         Event::listen(ComponentFolded::class, function (ComponentFolded $event) {
             $this->foldedEvents[] = $event;
         });
@@ -260,6 +267,10 @@ class BlazeManager
      */
     public function debug()
     {
+        if ($this->debug) {
+            return;
+        }
+        
         $this->debug = true;
 
         DebuggerMiddleware::register();

--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -11,6 +11,8 @@ class BlazeServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->registerConfig();
+
         $this->app->singleton(BlazeRuntime::class);
         $this->app->singleton(Config::class);
         $this->app->singleton(Debugger::class);
@@ -22,6 +24,15 @@ class BlazeServiceProvider extends ServiceProvider
         $this->app->alias(BlazeRuntime::class, 'blaze.runtime');
         $this->app->alias(Config::class, 'blaze.config');
         $this->app->alias(Debugger::class, 'blaze.debugger');
+    }
+
+    protected function registerConfig(): void
+    {
+        $config = __DIR__.'/../config/blaze.php';
+
+        $this->publishes([$config => base_path('config/blaze.php')], ['blaze', 'blaze:config']);
+
+        $this->mergeConfigFrom($config, 'blaze');
     }
 
     public function boot(): void


### PR DESCRIPTION
# The scenario

Toggling Blaze on/off or enabling debug mode during development.

# The problem

The only way to disable Blaze or enable debug mode is by calling `Blaze::disable()` or `Blaze::debug()` in a service provider. This means the change ends up in your committed code, which we don't want — it's easy to accidentally ship a `Blaze::disable()` call to production.

# The solution

Add a `config/blaze.php` config file with `BLAZE_ENABLED` and `BLAZE_DEBUG` env vars:

```php
return [
    'enabled' => env('BLAZE_ENABLED', true),
    'debug' => env('BLAZE_DEBUG', false),
];
```

`BlazeManager` reads these values on construction, and the config is publishable via `php artisan vendor:publish --tag=blaze:config`.