### PR TITLE
Fix optimize compilation by preserving Blade compiler app context

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Facade;
 
 test('ignores verbatim blocks', function () {
     $input = '@verbatim<x-input />@endverbatim';
@@ -18,6 +20,24 @@ test('ignores comments', function () {
     $input = '{{-- <x-input /> --}}';
 
     expect(Blade::render($input))->toBe('');
+});
+
+test('compiles using original app context when global container is swapped', function () {
+    $compiler = app('blade.compiler');
+    $originalApp = app();
+
+    $swapped = new Container;
+    Container::setInstance($swapped);
+    Facade::setFacadeApplication($swapped);
+
+    try {
+        $compiled = $compiler->compileString("@php \$name = 'Taylor'; @endphp\n<div>{{ \$name }}</div>");
+    } finally {
+        Container::setInstance($originalApp);
+        Facade::setFacadeApplication($originalApp);
+    }
+
+    expect($compiled)->not->toContain('@__raw_block_');
 });
 
 // TODO: Install PHPStan, which probably would have caught this.


### PR DESCRIPTION
## Summary
- bind Blaze's pre-compilation callback to the original application/container that registered the Blade compiler hook
- temporarily restore that app as the active Container/Facade context while the callback runs
- add a regression test to ensure compilation still works when the global container has been swapped

Fixes #43.

## Testing
- composer test