### PR TITLE
Fix optimize compilation by preserving Blade compiler app context

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Facade;
 
 test('ignores verbatim blocks', function () {
     $input = '@verbatim<x-input />@endverbatim';
@@ -18,6 +20,24 @@ test('ignores comments', function () {
     $input = '{{-- <x-input /> --}}';
 
     expect(Blade::render($input))->toBe('');
+});
+
+test('compiles using original app context when global container is swapped', function () {
+    $compiler = app('blade.compiler');
+    $originalApp = app();
+
+    $swapped = new Container;
+    Container::setInstance($swapped);
+    Facade::setFacadeApplication($swapped);
+
+    try {
+        $compiled = $compiler->compileString("@php \$name = 'Taylor'; @endphp\n<div>{{ \$name }}</div>");
+    } finally {
+        Container::setInstance($originalApp);
+        Facade::setFacadeApplication($originalApp);
+    }
+
+    expect($compiled)->not->toContain('@__raw_block_');
 });
 
 // TODO: Install PHPStan, which probably would have caught this.


### PR DESCRIPTION
## Summary
- execute Blaze pre-compilation callbacks in the original Blade compiler application context
- temporarily restore Container + Facade app context while callback logic runs
- add regression coverage for container/app swaps during compilation

Fixes #43.

## Testing
- composer test