### PR TITLE
Optimize path matching and reflection hot paths during compilation

### DIFF
--- a/src/Compiler/Wrapper.php
+++ b/src/Compiler/Wrapper.php
@@ -12,6 +12,13 @@ use Illuminate\Support\Arr;
  */
 class Wrapper
 {
+    /**
+     * Cached reflection properties for Blade compiler classes.
+     *
+     * @var array<string, \ReflectionProperty>
+     */
+    protected static $echoHandlersProperties = [];
+
     public function __construct(
         protected PropsCompiler $propsCompiler = new PropsCompiler,
         protected AwareCompiler $awareCompiler = new AwareCompiler,
@@ -118,9 +125,13 @@ class Wrapper
     protected function hasEchoHandlers(): bool
     {
         $compiler = app('blade.compiler');
-        $reflection = new \ReflectionProperty($compiler, 'echoHandlers');
+        $class = $compiler::class;
 
-        return ! empty($reflection->getValue($compiler));
+        if (! isset(static::$echoHandlersProperties[$class])) {
+            static::$echoHandlersProperties[$class] = new \ReflectionProperty($compiler, 'echoHandlers');
+        }
+
+        return ! empty(static::$echoHandlersProperties[$class]->getValue($compiler));
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Livewire\Blaze\Config;
+
+test('re-evaluates decisions when optimization rules change', function () {
+    $root = sys_get_temp_dir() . '/blaze-config-' . str_replace('.', '', uniqid('', true));
+    $components = $root . '/components';
+    $nested = $components . '/admin';
+    $file = $nested . '/panel.blade.php';
+
+    File::ensureDirectoryExists($nested);
+    File::put($file, '<div />');
+
+    try {
+        $config = new Config;
+
+        $config->add($components, true);
+        expect($config->shouldCompile($file))->toBeTrue();
+
+        // Updating rules must invalidate memoized per-file decisions.
+        $config->add($nested, false);
+        expect($config->shouldCompile($file))->toBeFalse();
+
+        $config->add($nested, true);
+        expect($config->shouldCompile($file))->toBeTrue();
+    } finally {
+        File::deleteDirectory($root);
+    }
+});
+
+test('supports config paths created after registration', function () {
+    $root = sys_get_temp_dir() . '/blaze-config-' . str_replace('.', '', uniqid('', true));
+    $futureDir = $root . '/future-components';
+    $futureFile = $futureDir . '/fresh.blade.php';
+
+    File::ensureDirectoryExists($root);
+
+    try {
+        $config = new Config;
+        $config->add($futureDir, true);
+
+        expect($config->shouldCompile($futureFile))->toBeFalse();
+
+        File::ensureDirectoryExists($futureDir);
+        File::put($futureFile, '<div />');
+
+        expect($config->shouldCompile($futureFile))->toBeTrue();
+    } finally {
+        File::deleteDirectory($root);
+    }
+});


### PR DESCRIPTION
## Summary
- cache resolved optimize config paths and per-file strategy decisions in `Config`
- cache Blade compiler reflection methods used in hot compilation paths
- cache Wrapper echo-handler reflection property lookup
- add Config tests for cache invalidation and late-created path handling

## Testing
- composer test