### PR TITLE
Add nikic/php-parser runtime dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/view": "^10.0|^11.0|^12.0"
+        "illuminate/view": "^10.0|^11.0|^12.0",
+        "nikic/php-parser": "^5.0"
     },
     "require-dev": {
         "livewire/flux": "dev-main",


### PR DESCRIPTION
## Summary

This PR adds `nikic/php-parser` as a runtime dependency for `livewire/blaze`.

## Problem

Blaze currently uses `PhpParser\ParserFactory` in runtime code (`src/Compiler/ArrayParser.php` and `src/Compiler/UseExtractor.php`) but does not declare `nikic/php-parser` in `require`.

In consumer applications that deploy with `composer install --no-dev`, this can cause runtime failures like:

> Class "PhpParser\\ParserFactory" not found

This breaks startup flows that run commands such as `php artisan optimize`.