### PR TITLE
Freeze all properties during isolated render

### DIFF
--- a/src/BladeService.php
+++ b/src/BladeService.php
@@ -111,17 +111,28 @@ class BladeService
         $factory = app('view');
 
         [$factory, $restoreFactory] = static::freezeObjectProperties($factory, [
+            'renderCount' => 0,
+            'renderedOnce' => [],
+            'sections' => [],
+            'sectionStack' => [],
+            'pushes' => [],
+            'prepends' => [],
+            'pushStack' => [],
             'componentStack' => [],
             'componentData' => [],
             'currentComponentData' => [],
             'slots' => [],
             'slotStack' => [],
-            'renderCount' => 0,
+            'fragments' => [],
+            'fragmentStack' => [],
+            'loopsStack' => [],
+            'translationReplacements' => [],
         ]);
 
         [$compiler, $restore] = static::freezeObjectProperties($compiler, [
             'cachePath' => $temporaryCachePath,
-            'rawBlocks',
+            'rawBlocks' => [],
+            'footer' => [],
             'prepareStringsForCompilationUsing' => [
                 function ($input) {
                     if (Unblaze::hasUnblaze($input)) {
@@ -135,6 +146,10 @@ class BladeService
                 },
             ],
             'path' => null,
+            'forElseCounter' => 0,
+            'firstCaseInSwitch' => true,
+            'lastSection' => null,
+            'lastFragment' => null,
         ]);
 
         [$runtime, $restoreRuntime] = static::freezeObjectProperties(app('blaze.runtime'), [


### PR DESCRIPTION
# The scenario

A view uses `@section` containing a component whose template hasn't been compiled yet and includes a foldable Flux component:

```blade
{{-- welcome.blade.php --}}
@extends('layout')

@section('content')
    <x-wrapper />
@endsection
```

```blade
{{-- wrapper.blade.php --}}
<flux:input />
```

On the first request after clearing the view cache:

```
Cannot end a section without first starting one.
```

# The problem

Laravel tracks a section stack. At the end of a rendering process, it flushes this stack.

Folding renders its own view internally via `isolatedRender()`. When that render completes, Laravel flushes the section stack — wiping the parent's in-progress `@section`.

```
@section (stack++)
    <x-wrapper> → compile → fold → flush (stack = 0)
@endsection → 💥
```

On subsequent requests the child view is already compiled, so no folding happens and the bug doesn't surface.

# The solution

We already freeze and restore some view factory and compiler properties during isolated render, but we were missing sections. Added all remaining stateful properties so the parent's state is fully preserved.

Fixes #60