### PR TITLE
Fix env options

### DIFF
--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -44,6 +44,7 @@ class BlazeServiceProvider extends ServiceProvider
         $this->registerBladeMacros();
         $this->interceptViewCacheInvalidation();
         $this->interceptBladeCompilation();
+        $this->registerDebuggerMiddleware();
     }
 
     /**
@@ -130,5 +131,15 @@ class BlazeServiceProvider extends ServiceProvider
                 $invalidate();
             }
         });
+    }
+
+    /**
+     * Register the Debugger middleware.
+     */
+    protected function registerDebuggerMiddleware(): void
+    {
+        if (Blaze::isDebugging()) {
+            DebuggerMiddleware::register();
+        }
     }
 }


### PR DESCRIPTION
# The scenario

Setting `BLAZE_DEBUG=true` in `.env` didn't work.

# The problem

We resolved config values in `BlazeManager`'s constructor, where they weren't available yet.

# The solution

Moved config resolution into the getter methods as a fallback:

```php
public function isDebugging()
{
    return $this->debug ?? config('blaze.debug', false);
}
```

`Blaze::enable()`, `Blaze::disable()`, and `Blaze::debug()` take precedence over the fallback.

Moved `DebuggerMiddleware` registration into `BlazeServiceProvider::boot()`.