### PR TITLE
Fix raw block restoration

### DIFF
--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -148,6 +148,10 @@ class BlazeManager
 
         $output = $this->render($ast);
 
+        // We should not restore raw blocks here. Doing so would preemptively
+        // flush all raw blocks stored in the original template and they
+        // wouldn't be restored in the parent compile() method.
+
         return $output;
     }
 
@@ -187,6 +191,8 @@ class BlazeManager
             $output = $this->instrumenter->profileView($output, $path, $source);
         }
 
+        $output = BladeService::restoreRawBlocks($output);
+
         return $output;
     }
 
@@ -210,6 +216,8 @@ class BlazeManager
         );
 
         $output = $this->render($ast);
+
+        $output = BladeService::restoreRawBlocks($output);
 
         $path = app('blade.compiler')->getPath();
 

--- a/tests/BlazeManagerTest.php
+++ b/tests/BlazeManagerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Livewire\Blaze\Blaze;
+
+test('compile preserves php directives', function () {
+    $input = '@php /* uncompiled */ @endphp';
+
+    expect(Blaze::compile($input))->toBe($input);
+});
+
+test('compileForDebug preserves php directives', function () {
+    $input = '@php /* uncompiled */ @endphp';
+
+    expect(Blaze::compileForDebug($input))->toBe($input);
+});
+
+test('compileForFolding preserves php directives', function () {
+    $input = '@php /* uncompiled */ @endphp';
+
+    expect(Blaze::compileForFolding($input))->toBe($input);
+});
+
+test('compileForUnblaze does not restore raw blocks', function () {
+    $input = '@php /* uncompiled */ @endphp';
+
+    // compileForUnblaze should only store raw blocks, not restore them.
+    // They will be restored in the parent compile() method.
+    expect(Blaze::compileForUnblaze($input))->toBe('@__raw_block_0__@');
+});

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -21,13 +21,6 @@ test('ignores comments', function () {
     expect(Blade::render($input))->toBe('');
 });
 
-test('preserves php directives', function () {
-    $input = '@php /* uncompiled */ @endphp';
-
-    expect(Blaze::compile($input))->toBe($input);
-});
-
-// TODO: Install PHPStan, which probably would have caught this.
 test('supports php engine', function () {
     // Make sure our hooks do not break views
     // rendered using the regular php engine.


### PR DESCRIPTION
# The scenario

Having Blaze debug turned on with Blaze disabled causes regular non-Blaze views with `@php` directives to compile incorrectly:

```
BLAZE_ENABLED=false
BLAZE_DEBUG=true
```


```blade
<div>
    @php
        $name = 'World';
    @endphp

    Hello, {{ $name }}
</div>
```

Compiles to:

```php
<div>
    @php
        $name = 'World';
    @endphp

    Hello, <?php echo e($name); ?>
</div>
```

# The problem

During compilation, we store raw blocks as placeholders to avoid parsing their contents. Unlike Laravel, we don't restore them to `<?php` / `?>` — we restore them back to `@php` / `@endphp` and leave the final transformation to Laravel's compiler.

We do this to avoid transforming the PHP tags too early, which can cause issues — for example, Livewire injects morph markers around raw PHP tags but skips @php directives.

In `compileForDebug()`, we forgot to add these restoration calls. The placeholders survive into Blade's compilation, where they get replaced with `@php` / `@endphp` literally in the final output instead of executable PHP.

Introduced in #66.

# The solution

Restore raw blocks at the end of `compileForDebug()` and `compileForFolding()` so they're converted back to `@php` / `@endphp` directives before Blade takes over.