### PR TITLE
Fix debug mode registration

### DIFF
--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -138,8 +138,10 @@ class BlazeServiceProvider extends ServiceProvider
      */
     protected function registerDebuggerMiddleware(): void
     {
-        if (Blaze::isDebugging()) {
-            DebuggerMiddleware::register();
-        }
+        $this->app->booted(function () {
+            if (Blaze::isDebugging()) {
+                DebuggerMiddleware::register();
+            }
+        });
     }
 }

--- a/src/DebuggerMiddleware.php
+++ b/src/DebuggerMiddleware.php
@@ -3,6 +3,7 @@
 namespace Livewire\Blaze;
 
 use Closure;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
@@ -25,7 +26,7 @@ class DebuggerMiddleware
             return response($html)->header('Content-Type', 'text/html');
         })->middleware('web');
 
-        app('router')->pushMiddlewareToGroup('web', static::class);
+        app(Kernel::class)->pushMiddleware(static::class);
     }
 
     /**


### PR DESCRIPTION
# The scenario

Enabling debug mode via `BLAZE_DEBUG=true` or `Blaze::debug()` in a service provider.

# The problem

**1. Debug middleware not registering in apps with Nightwatch**

We were pushing the debugger middleware directly to the Router's `web` group:

```php
app('router')->pushMiddlewareToGroup('web', static::class);
```

The standard pattern used by Debugbar, Nova, Livewire, Nightwatch, and Workbench is to register on the Kernel instead:

```php
app(Kernel::class)->pushMiddleware(static::class);
```

The Kernel is the source of truth for middleware groups — the Router's groups can be overwritten by the Kernel's state at any point via `syncMiddlewareToRouter()`. Nightwatch calls `$kernel->prependToMiddlewarePriority()` during provider registration, which internally calls `syncMiddlewareToRouter()`, wiping our middleware from the Router.

**2. `Blaze::debug()` in a service provider has no effect**

In #69 we moved middleware registration to `boot()`, but that runs before the user has a chance to call `Blaze::debug()` in their own service provider.

# The solution

Register as global Kernel middleware and defer the check to a `booted` callback.