### PR TITLE
Fix directives detected inside Blade comments

### DIFF
--- a/src/Support/Directives.php
+++ b/src/Support/Directives.php
@@ -2,7 +2,6 @@
 
 namespace Livewire\Blaze\Support;
 
-use Illuminate\Support\Arr;
 use Livewire\Blaze\BladeService;
 use Livewire\Blaze\Compiler\ArrayParser;
 
@@ -14,6 +13,7 @@ class Directives
     public function __construct(
         protected string $content,
     ) {
+        $this->content = BladeService::compileComments($this->content);
         $this->content = preg_replace('/(?<!@)@verbatim(\s*)(.*?)@endverbatim/s', '', $this->content);
         $this->content = preg_replace('/(?<!@)@php(.*?)@endphp/s', '', $this->content);
     }

--- a/tests/Support/DirectivesTest.php
+++ b/tests/Support/DirectivesTest.php
@@ -8,3 +8,7 @@ test('ignores directives in php blocks', function ($input) {
     ['@php // @aware @endphp'],
     ['<?php // @aware ?>'],
 ]);
+
+test('ignores directives in comments', function () {
+    expect((new Directives('{{-- @aware --}}'))->has('aware'))->toBeFalse();
+});


### PR DESCRIPTION
# The scenario

Directives inside Blade comments are picked up by Blaze:

```blade
{{-- no @blaze --}}
```

# The problem

The `Directives` class strips `@php` and `@verbatim` blocks before scanning, but doesn't strip Blade comments.

# The solution

Strip Blade comments before scanning for directives:

```php
$this->content = BladeService::compileComments($this->content);
```

Fixes #75