### PR TITLE
Support route prefix for Blaze and profiler

### DIFF
--- a/config/blaze.php
+++ b/config/blaze.php
@@ -28,4 +28,17 @@ return [
 
     'debug' => env('BLAZE_DEBUG', false),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Route Prefix
+    |--------------------------------------------------------------------------
+    |
+    | If your application is served from a subdirectory or with a custom
+    | route prefix, specify it here so Blaze's profiler routes are
+    | registered at the correct path.
+    |
+    */
+
+    'route_prefix' => env('BLAZE_ROUTE_PREFIX', ''),
+
 ];

--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -138,10 +138,9 @@ class BlazeServiceProvider extends ServiceProvider
      */
     protected function registerDebuggerMiddleware(): void
     {
-        $this->app->booted(function () {
-            if (Blaze::isDebugging()) {
-                DebuggerMiddleware::register();
-            }
-        });
+        if (Blaze::isDebugging()) {
+            $prefix = config('blaze.route_prefix', '');
+            DebuggerMiddleware::register($prefix);
+        }
     }
 }

--- a/src/Profiler/profiler.html
+++ b/src/Profiler/profiler.html
@@ -823,7 +823,8 @@ function buildRenderList() {
 // ─── Data Fetch ─────────────────────────────────────────────────────
 async function fetchTrace() {
     try {
-        const resp = await fetch('/_blaze/trace');
+        const prefix = window.__blazeRoutePrefix || '';
+        const resp = await fetch(prefix + '/_blaze/trace');
         data = await resp.json();
         entries = data.entries || [];
         processData();


### PR DESCRIPTION
  - Add 'route_prefix' config option for custom profiler paths
  - Update DebuggerMiddleware to accept and register prefixed routes
  - Inject window.__blazeRoutePrefix into profiler HTML
  - Fix middleware skip condition with str_contains()
  - Move middleware registration from booted() to boot() method

  Allows Blaze profiler to work when served from subdirectories.