### PR TITLE
Fix `@assets` directive not loading in Blaze-compiled views

### DIFF
--- a/src/Compiler/Wrapper.php
+++ b/src/Compiler/Wrapper.php
@@ -30,7 +30,7 @@ class Wrapper
         $source ??= $compiled;
         $name = (Blaze::isFolding() ? '__' : '_') . Utils::hash($path);
 
-        $sourceUsesThis = str_contains($source, '$this') || str_contains($compiled, '@entangle') || str_contains($compiled, '@script');
+        $sourceUsesThis = str_contains($source, '$this') || str_contains($compiled, '@entangle') || str_contains($compiled, '@script') || str_contains($compiled, '@assets');
 
         $compiled = BladeService::compileUseStatements($compiled);
         $compiled = BladeService::restoreRawBlocks($compiled);

--- a/tests/Compiler/WrapperTest.php
+++ b/tests/Compiler/WrapperTest.php
@@ -71,6 +71,7 @@ test('wraps in self invoking closure', function ($source) {
     '{{ $this->orders }}',
     '@entangle(\'name\')',
     '@script',
+    '@assets',
 ]);
 
 test('injects variables', function ($source, $expected) {


### PR DESCRIPTION
# The Scenario

When using Livewire's `@assets` directive inside a Blade component compiled by Blaze, the assets (scripts/styles) fail to load. This affects any component that uses `@assets`, including the Flux `<flux:editor>` component, which relies on `@assets` to load its JS and CSS.

The issue is most visible when the component is rendered dynamically via a Livewire AJAX request (e.g. lazy-loaded or conditionally rendered):

![Screenshot 2026-02-28 at 09 39 35AM](https://github.com/user-attachments/assets/4f80c06d-1d7a-4cc5-a193-6c6ee379ccd8)

```php
<?php

use Livewire\Component;

new class extends Component {
    public bool $show_editor = false;

    public function showEditor()
    {
        $this->show_editor = true;
    }
}; ?>

<div>
    @if ($show_editor)
        <flux:editor />
    @else
        <flux:button wire:click="showEditor">Show Editor</flux:button>
    @endif
</div>
```

Clicking "Show Editor" renders the editor HTML but the toolbar and formatting are broken because the editor's JS and CSS are never loaded. Disabling Blaze fixes the issue.

# The Problem

Blaze compiles Blade component templates into plain PHP functions. Since `$this` is not available inside plain functions, Blaze detects when a template needs `$this` and wraps the function body in a closure that is bound via `Closure::bind()`. The detection in `Wrapper.php` checks for `$this`, `@entangle`, and `@script`, but not `@assets`:

```php
$sourceUsesThis = str_contains($source, '$this') || str_contains($compiled, '@entangle') || str_contains($compiled, '@script');
```

Livewire's `@endassets` directive compiles to code that checks `isset($this)` to decide whether to store assets in the Livewire component store (for AJAX delivery) or a static fallback array (for HTML injection on initial page loads). Without the closure binding, `$this` is never available, so assets always go to the fallback path. This fallback only works for initial HTML responses; on AJAX requests (lazy loading, conditional rendering, etc.), the assets are never sent to the browser.

# The Solution

Add `@assets` to the list of directives that trigger the `$this` closure binding in `Wrapper::wrap()`, consistent with how `@script` and `@entangle` are already handled.

![Screenshot 2026-02-28 at 09 40 45AM](https://github.com/user-attachments/assets/8abc2377-6a42-4aa3-ada2-b4a2e1a0eb98)

Fixes livewire/livewire#10067
Fixes livewire/flux#2442