### PR TITLE
Fix Statamic serialization issue

### DIFF
--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -7,6 +7,7 @@ use Livewire\Blaze\Runtime\BlazeRuntime;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\View;
+use Illuminate\View\Engines\CompilerEngine;
 
 class BlazeServiceProvider extends ServiceProvider
 {
@@ -48,11 +49,20 @@ class BlazeServiceProvider extends ServiceProvider
     }
 
     /**
-     * Share the BlazeRuntime instance with all views.
+     * Make the BlazeRuntime instance available to Blade views.
      */
     protected function registerBlazeRuntime(): void
     {
-        View::share('__blaze', $this->app->make(BlazeRuntime::class));
+        View::composer('*', function (\Illuminate\View\View $view) {
+            if (Blaze::isDisabled()) {
+                return;
+            }
+
+            // Avoid injecting the BlazeRuntime into non-Blade views (like Statamic's Antlers)
+            if ($view->getEngine() instanceof CompilerEngine) {
+                $view->with('__blaze', $this->app->make(BlazeRuntime::class));
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
# The scenario

Installing Blaze alongside Statamic and visiting any Statamic page that uses a `{{ nocache }}` tag throws an exception

```
Serialization of 'Closure' is not allowed
  at Illuminate\Cache\FileStore.php:92
```

# The problem

`View::share()` injects data into every view engine registered in Laravel -- not just Blade. `BlazeRuntime` was shared globally via `View::share('__blaze', ...)`, which meant it landed in Statamic's Antlers template context too.

Statamic's `{{ nocache }}` feature serializes the template context so it can replay dynamic sections from cache. `BlazeRuntime` holds the Application container and the Blade compiler, both of which contain Closures that can't be serialized:

This happened even with `BLAZE_ENABLED=false` because the `View::share()` call ran unconditionally in `boot()`.

# The solution

Replace `View::share()` with a `View::composer('*', ...)` that checks `$view->getEngine() instanceof CompilerEngine` before injecting `__blaze`. This scopes the runtime to Blade views only and keeps it out of Antlers and any other non-Blade engine.

```php
View::composer('*', function (\Illuminate\View\View $view) {
    // Avoid injecting the BlazeRuntime into non-Blade views (like Statamic's Antlers)
    if ($view->getEngine() instanceof CompilerEngine) {
        $view->with('__blaze', $this->app->make(BlazeRuntime::class));
    }
});
```

Fixes livewire/blaze#83