### PR TITLE
Fix debug mode

### DIFF
--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -54,7 +54,7 @@ class BlazeServiceProvider extends ServiceProvider
     protected function registerBlazeRuntime(): void
     {
         View::composer('*', function (\Illuminate\View\View $view) {
-            if (Blaze::isDisabled()) {
+            if (Blaze::isDisabled() && ! Blaze::isDebugging()) {
                 return;
             }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,7 +1,31 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Blaze\Blaze;
+
+test('renders components', function () {
+    Artisan::call('view:clear');
+    
+    view('inputs')->render();
+})->throwsNoExceptions();
+
+test('renders components with blaze off', function () {
+    Artisan::call('view:clear');
+
+    Blaze::disable();
+    
+    view('inputs')->render();
+})->throwsNoExceptions();
+
+test('renders components with blaze off and debug mode on', function () {
+    Artisan::call('view:clear');
+
+    Blaze::disable();
+    Blaze::debug();
+    
+    view('inputs')->render();
+})->throwsNoExceptions();
 
 test('ignores verbatim blocks', function () {
     $input = '@verbatim<x-input />@endverbatim';

--- a/tests/fixtures/components/input-no-blaze.blade.php
+++ b/tests/fixtures/components/input-no-blaze.blade.php
@@ -1,0 +1,9 @@
+@blaze
+
+@props(['type' => 'text', 'disabled' => false])
+
+<input
+    {{ $attributes }}
+    type="{{ $type }}"
+    @if ($disabled) disabled @endif
+>

--- a/tests/fixtures/views/inputs.blade.php
+++ b/tests/fixtures/views/inputs.blade.php
@@ -1,0 +1,2 @@
+<x-input />
+<x-input-no-blaze />


### PR DESCRIPTION
# The scenario

Rendering a view with Blaze disabled and debug mode on throws an undefined variable `$__blaze` exception.

# The problem

In #89 we moved from `View::share()` to `View::composer()` and added a `Blaze::isDisabled()` guard. This guard bails out of injecting `__blaze` entirely when Blaze is off — even when debug mode is on.

Debug mode needs `__blaze` to inject debug markers into views so it can profile regular Blade rendering without Blaze enabled.

# The solution

Only skip injection when Blaze is disabled *and* debug mode is off:

```php
if (Blaze::isDisabled() && ! Blaze::isDebugging()) {
    return;
}
```

Added integration tests for rendering with Blaze off and with Blaze off + debug mode on.