### PR TITLE
Fix runtime injection for decorated Blade engines

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\View\Engine;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Blaze\Blaze;
@@ -49,4 +50,30 @@ test('supports php engine', function () {
     // Make sure our hooks do not break views
     // rendered using the regular php engine.
     view('php-view')->render();
+})->throwsNoExceptions();
+
+test('injects blaze runtime when blade engine is decorated', function () {
+    Artisan::call('view:clear');
+
+    $resolver = app('view.engine.resolver');
+    $bladeEngine = $resolver->resolve('blade');
+
+    $resolver->register('blade', function () use ($bladeEngine) {
+        return new class ($bladeEngine) implements Engine
+        {
+            public function __construct(protected Engine $engine) {}
+
+            public function get($path, array $data = [])
+            {
+                return $this->engine->get($path, $data);
+            }
+
+            public function getEngine(): Engine
+            {
+                return $this->engine;
+            }
+        };
+    });
+
+    view('inputs')->render();
 })->throwsNoExceptions();


### PR DESCRIPTION
## Summary
This fixes a regression in v1.0.3 where Blaze runtime injection can be skipped when the Blade engine is wrapped by a decorator (for example Sentry's `ViewEngineDecorator`).

## What changed
- Resolve wrapped/decorated view engines by unwrapping `getEngine()` until a `CompilerEngine` is found
- Keep the existing guard so non-Blade engines still do not receive `__blaze`
- Add a regression integration test that wraps the blade engine and verifies rendering does not fail

## Why this is needed
In the current code, `registerBlazeRuntime()` only checks `instanceof CompilerEngine` on the top-level engine object. Decorators are not `CompilerEngine`, so `__blaze` is not injected and compiled views can fail with `Undefined variable $__blaze`.

## Verification
- Added test: `injects blaze runtime when blade engine is decorated`
- Full test suite passes locally (`vendor/bin/pest`)