### PR TITLE
fix: add file_exists check to ensureCompiled in-memory cache guard

### DIFF
--- a/src/Runtime/BlazeRuntime.php
+++ b/src/Runtime/BlazeRuntime.php
@@ -45,7 +45,7 @@ class BlazeRuntime
      */
     public function ensureCompiled(string $path, string $compiledPath): void
     {
-        if (isset($this->compiled[$path])) {
+        if (isset($this->compiled[$path]) && file_exists($compiledPath)) {
             return;
         }
 


### PR DESCRIPTION
## Summary

- Adds a `file_exists($compiledPath)` check to the in-memory cache guard in `ensureCompiled()`
- Prevents `require_once` errors when compiled view files are deleted while the process is still running (e.g. via `artisan view:clear`)
- Minimal, non-breaking change — only one line modified

## Problem

The `ensureCompiled()` method caches compilation status in `$this->compiled[$path]`. Once a view is compiled during a request, subsequent calls skip recompilation. However, if the compiled file is removed from disk (e.g. `view:clear`, deployment, or manual deletion), the stale in-memory cache causes `require_once` to fail because the file no longer exists.

## Solution

```php
// Before
if (isset($this->compiled[$path])) {
    return;
}

// After
if (isset($this->compiled[$path]) && file_exists($compiledPath)) {
    return;
}
```

The additional `file_exists()` check ensures recompilation is triggered when the compiled file has been removed, while preserving the performance benefit of in-memory caching for the normal case.

## Test plan

- [x] All 138 existing tests pass (`composer test`)
- [x] No breaking changes to existing behavior

Fixes #96