### PR TITLE
Add fast paths for class/style string arguments in BlazeAttributeBag

### DIFF
--- a/src/Runtime/BlazeAttributeBag.php
+++ b/src/Runtime/BlazeAttributeBag.php
@@ -49,6 +49,11 @@ class BlazeAttributeBag extends ComponentAttributeBag
     /** {@inheritdoc} */
     public function merge(array $attributeDefaults = [], $escape = true): static
     {
+        // Fast path: merge(['class' => 'string']) — the most common pattern.
+        if (count($attributeDefaults) === 1 && isset($attributeDefaults['class']) && is_string($attributeDefaults['class'])) {
+            return $this->withMergedClass($escape ? e($attributeDefaults['class']) : $attributeDefaults['class']);
+        }
+
         if ($escape) {
             foreach ($attributeDefaults as $key => $value) {
                 if ($this->shouldEscapeAttributeValue($escape, $value)) {
@@ -103,6 +108,10 @@ class BlazeAttributeBag extends ComponentAttributeBag
     /** {@inheritdoc} */
     public function class($classList): static
     {
+        if (is_string($classList)) {
+            return $this->withMergedClass(e($classList));
+        }
+
         $classes = $this->toCssClasses(Arr::wrap($classList));
 
         return $this->merge(['class' => $classes]);
@@ -111,9 +120,43 @@ class BlazeAttributeBag extends ComponentAttributeBag
     /** {@inheritdoc} */
     public function style($styleList): static
     {
+        if (is_string($styleList)) {
+            $default = e(rtrim($styleList, ';').';');
+            $current = $this->attributes['style'] ?? '';
+
+            if ($current) {
+                $current = rtrim((string) $current, ';').';';
+                $style = $current === $default ? $default : $default.' '.$current;
+            } else {
+                $style = $default;
+            }
+
+            return new static(['style' => $style] + $this->attributes);
+        }
+
         $styles = $this->toCssStyles((array) $styleList);
 
         return $this->merge(['style' => $styles]);
+    }
+
+    /**
+     * Return a new bag with the given class default merged into the current class attribute.
+     */
+    protected function withMergedClass(string $default): static
+    {
+        $current = $this->attributes['class'] ?? '';
+
+        if (! $current || $current === $default) {
+            $class = $default;
+        } elseif (! $default) {
+            $class = $current ?: '';
+        } else {
+            $class = $default.' '.$current;
+        }
+
+        // Array union places class first, matching merge()'s
+        // array_merge($attributeDefaults, $attributes) key ordering.
+        return new static(['class' => $class] + $this->attributes);
     }
 
     /**

--- a/src/Runtime/BlazeAttributeBag.php
+++ b/src/Runtime/BlazeAttributeBag.php
@@ -49,8 +49,9 @@ class BlazeAttributeBag extends ComponentAttributeBag
     /** {@inheritdoc} */
     public function merge(array $attributeDefaults = [], $escape = true): static
     {
-        // Fast path: merge(['class' => 'string']) — the most common pattern.
-        if (count($attributeDefaults) === 1 && isset($attributeDefaults['class']) && is_string($attributeDefaults['class'])) {
+        // Fast path: merge(['class' => 'string']) — the most common pattern. Skipped when the
+        // bag contains a style attribute, which merge() normalizes and reorders alongside class.
+        if (count($attributeDefaults) === 1 && isset($attributeDefaults['class']) && is_string($attributeDefaults['class']) && ! isset($this->attributes['style'])) {
             return $this->withMergedClass($escape ? e($attributeDefaults['class']) : $attributeDefaults['class']);
         }
 
@@ -108,7 +109,7 @@ class BlazeAttributeBag extends ComponentAttributeBag
     /** {@inheritdoc} */
     public function class($classList): static
     {
-        if (is_string($classList)) {
+        if (is_string($classList) && ! isset($this->attributes['style'])) {
             return $this->withMergedClass(e($classList));
         }
 
@@ -120,11 +121,11 @@ class BlazeAttributeBag extends ComponentAttributeBag
     /** {@inheritdoc} */
     public function style($styleList): static
     {
-        if (is_string($styleList)) {
+        if (is_string($styleList) && ! isset($this->attributes['class'])) {
             $default = e(rtrim($styleList, ';').';');
-            $current = $this->attributes['style'] ?? '';
+            $current = $this->attributes['style'] ?? null;
 
-            if ($current) {
+            if ($current !== null) {
                 $current = rtrim((string) $current, ';').';';
                 $style = $current === $default ? $default : $default.' '.$current;
             } else {

--- a/tests/ComparisonTest.php
+++ b/tests/ComparisonTest.php
@@ -95,6 +95,11 @@ test('nested same component with different component in between', fn () => compa
     BLADE
 ));
 
+test('merge preserves attribute ordering', fn () => compare(<<<'BLADE'
+    <x-merge-class wire:model="data" class="extra" wire:ignore />
+    BLADE
+));
+
 test('deeply nested same component with different components interleaved', fn () => compare(<<<'BLADE'
     <x-card class="outer">
         <x-wrapper>

--- a/tests/ComparisonTest.php
+++ b/tests/ComparisonTest.php
@@ -100,6 +100,19 @@ test('merge preserves attribute ordering', fn () => compare(<<<'BLADE'
     BLADE
 ));
 
+test('merge class with style attribute present', fn () => compare(<<<'BLADE'
+    <x-merge-class wire:model="data" style="color:blue" class="extra" />
+    BLADE
+));
+
+test('class and style string arguments', fn () => compare(<<<'BLADE'
+    <x-class-style-string wire:model="data" class="extra" style="color:blue" />
+    <x-class-style-string wire:model="data" class="extra" />
+    <x-class-style-string wire:model="data" style="color:blue" />
+    <x-class-style-string data-x="1" />
+    BLADE
+));
+
 test('deeply nested same component with different components interleaved', fn () => compare(<<<'BLADE'
     <x-card class="outer">
         <x-wrapper>

--- a/tests/fixtures/views/components/class-style-string.blade.php
+++ b/tests/fixtures/views/components/class-style-string.blade.php
@@ -1,0 +1,4 @@
+@blaze
+
+<div {{ $attributes->class('base') }}></div>
+<div {{ $attributes->style('color: red') }}></div>

--- a/tests/fixtures/views/components/merge-class.blade.php
+++ b/tests/fixtures/views/components/merge-class.blade.php
@@ -1,0 +1,3 @@
+@blaze
+
+<div {{ $attributes->merge(['class' => 'default-class']) }}></div>


### PR DESCRIPTION
When `merge()`, `class()`, or `style()` receive a simple string argument (the most common usage), skip the general-purpose loops and handle the merge directly.

The shared class-merging logic is extracted into `withMergedClass()` to avoid duplication between `merge()` and `class()`.

This replaces both PR #157 and #161 with a single combined PR.