### PR TITLE
Sort by slowest component in command trace list

### DIFF
--- a/src/Commands/TraceListCommand.php
+++ b/src/Commands/TraceListCommand.php
@@ -27,12 +27,14 @@ class TraceListCommand extends Command
 
         $this->table(
             ['ID', 'URL', 'Mode', 'Render Time', 'Recorded'],
-            collect($traces)->map(fn (array $trace) => [
-                $trace['id'],
-                $trace['url'] ?? '-',
-                $trace['mode'] ?? '-',
-                $this->formatMs($trace['renderTime'] ?? 0),
-                $trace['timestamp'] ? Carbon::parse($trace['timestamp'])->diffForHumans(short: true) : '-',
+            collect($traces)
+                ->sortByDesc(fn (array $trace) => $trace['renderTime'] ?? 0)
+                ->map(fn (array $trace) => [
+                    $trace['id'],
+                    $trace['url'] ?? '-',
+                    $trace['mode'] ?? '-',
+                    $this->formatMs($trace['renderTime'] ?? 0),
+                    $trace['timestamp'] ? Carbon::parse($trace['timestamp'])->diffForHumans(short: true) : '-',
             ])->all(),
         );
 


### PR DESCRIPTION
Hi, @ganyicz 

I think it would make more sense to show the slowest component first in `php artisan blaze:trace:list`.