### PR TITLE
[Refactor] Use short-circuit expression instead repeating check

### DIFF
--- a/src/Memoizer/Memoizer.php
+++ b/src/Memoizer/Memoizer.php
@@ -29,15 +29,7 @@ class Memoizer
      */
     public function memoize(Node $node): Node
     {
-        if (! $node instanceof ComponentNode) {
-            return $node;
-        }
-
-        if (! $node->selfClosing) {
-            return $node;
-        }
-
-        if (! $this->isMemoizable($node)) {
+        if (! $node instanceof ComponentNode || ! $node->selfClosing || ! $this->isMemoizable($node)) {
             return $node;
         }
 


### PR DESCRIPTION
Just a small refactor on [Memoizer.php](https://github.com/livewire/blaze/blob/main/src/Memoizer/Memoizer.php)

### Before
```php
if (! $node instanceof ComponentNode) {
    return $node;
}

if (! $node->selfClosing) {
    return $node;
}

if (! $this->isMemoizable($node)) {
    return $node;
}
```
### After
```php
if (! $node instanceof ComponentNode || ! $node->selfClosing || ! $this->isMemoizable($node)) {
    return $node;
}
```