### PR TITLE
Handle missing compiled views during folded expiry checks

### DIFF
--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -294,7 +294,13 @@ class BlazeManager
         $isExpired = false;
 
         if (! $expired) {
-            $contents = file_get_contents($compiled);
+            $contents = @file_get_contents($compiled);
+
+            if ($contents === false) {
+                $compiler->compile($path);
+
+                $contents = file_get_contents($compiled);
+            }
 
             $isExpired = (new FrontMatter)->sourceContainsExpiredFoldedDependencies($contents);
         }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -5,6 +5,9 @@ use Illuminate\Contracts\View\Engine;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\View\Component;
+use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\Engines\CompilerEngine;
+use Illuminate\View\View;
 use Livewire\Blaze\Blaze;
 use Livewire\Blaze\BlazeManager;
 use Livewire\Blaze\Runtime\BlazeRuntime;
@@ -35,6 +38,47 @@ test('renders components after clearing compiled views in the same process', fun
 
     view('mix')->render();
 })->throwsNoExceptions();
+
+test('recompiles when a compiled view disappears while checking folded dependencies', function () {
+    $path = storage_path('framework/testing/blaze-missing-compiled-view.blade.php');
+
+    app('files')->ensureDirectoryExists(dirname($path));
+    app('files')->put($path, 'Hello');
+
+    $compiler = new class(app('files'), config('view.compiled')) extends BladeCompiler {
+        public bool $deleteCompiledView = false;
+
+        public function isExpired($path)
+        {
+            $expired = parent::isExpired($path);
+
+            if (! $expired && $this->deleteCompiledView) {
+                unlink($this->getCompiledPath($path));
+            }
+
+            return $expired;
+        }
+    };
+
+    $compiler->compile($path);
+    touch($path, time() - 10);
+    touch($compiler->getCompiledPath($path), time());
+
+    $compiler->deleteCompiledView = true;
+
+    $view = new View(
+        app('view'),
+        new CompilerEngine($compiler),
+        'blaze-missing-compiled-view',
+        $path,
+    );
+
+    expect(app(BlazeManager::class)->viewContainsExpiredFrontMatter($view))->toBeFalse();
+    expect(file_exists($compiler->getCompiledPath($path)))->toBeTrue();
+
+    app('files')->delete($path);
+    app('files')->delete($compiler->getCompiledPath($path));
+});
 
 test('supports php engine', function () {
     view('php-view')->render();


### PR DESCRIPTION
Fixes #175.

Blaze checks folded front matter after Blade reports a compiled view is fresh. If that compiled file is removed before Blaze reads it, the read can fail instead of letting Blade rebuild the view.

This retries through the compiler once when that compiled file is missing, then checks the fresh compiled output.