### PR TITLE
Fix compiled path overrides after Blaze runtime resolution

### DIFF
--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -87,6 +87,8 @@ class BlazeServiceProvider extends ServiceProvider
                 $view->getEngine()->getCompiler()->compile($view->getPath());
             }
 
+            $runtime->syncCompiledPath();
+
             if ($blaze->isDebugging()) {
                 $debugger->injectRenderTimer($view);
 

--- a/src/Runtime/BlazeRuntime.php
+++ b/src/Runtime/BlazeRuntime.php
@@ -18,8 +18,8 @@ use Livewire\Blaze\Debugger;
  */
 class BlazeRuntime
 {
-    // Tests and isolated rendering temporarily override this property.
-    // When it is null we always read the current view.compiled config.
+    // Lazily cached from config('view.compiled') on first access via __get.
+    // Tests and isolated rendering can still override it temporarily.
     protected ?string $compiledPath = null;
 
     protected array $paths = [];
@@ -243,7 +243,7 @@ class BlazeRuntime
 
     private function getCompiledPath(): string
     {
-        return $this->compiledPath ?? config('view.compiled');
+        return $this->compiledPath ??= config('view.compiled');
     }
 
     private function getCompiler(): Compiler
@@ -267,6 +267,14 @@ class BlazeRuntime
     public function setApplication(Application $app): void
     {
         $this->app = $app;
+    }
+
+    /**
+     * Refresh the cached compiled path from the current config.
+     */
+    public function syncCompiledPath(): void
+    {
+        $this->compiledPath = config('view.compiled');
     }
 
     /**

--- a/src/Runtime/BlazeRuntime.php
+++ b/src/Runtime/BlazeRuntime.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\View\Compilers\BladeCompiler;
-use Illuminate\View\Compilers\Compiler;
 use Livewire\Blaze\BladeService;
 use Livewire\Blaze\Support\Directives;
 use Livewire\Blaze\Support\Utils;
@@ -48,7 +47,7 @@ class BlazeRuntime
         }
 
         if (! file_exists($compiledPath) || filemtime($path) > filemtime($compiledPath)) {
-            $this->getCompiler()->compile($path);
+            $this->compiler->compile($path);
         }
 
         require $compiledPath;
@@ -246,21 +245,6 @@ class BlazeRuntime
         return $this->compiledPath ??= config('view.compiled');
     }
 
-    private function getCompiler(): Compiler
-    {
-        $compiler = app('blade.compiler');
-        $compiledPath = $this->getCompiledPath();
-        static $cachePath;
-
-        $cachePath ??= new \ReflectionProperty($compiler, 'cachePath');
-
-        if ($cachePath->getValue($compiler) !== $compiledPath) {
-            $cachePath->setValue($compiler, $compiledPath);
-        }
-
-        return $compiler;
-    }
-
     /**
      * Set the application instance (used by Octane to swap in the sandbox).
      */
@@ -275,6 +259,14 @@ class BlazeRuntime
     public function syncCompiledPath(): void
     {
         $this->compiledPath = config('view.compiled');
+
+        static $cachePath;
+
+        $cachePath ??= new \ReflectionProperty($this->compiler, 'cachePath');
+
+        if ($cachePath->getValue($this->compiler) !== $this->compiledPath) {
+            $cachePath->setValue($this->compiler, $this->compiledPath);
+        }
     }
 
     /**

--- a/src/Runtime/BlazeRuntime.php
+++ b/src/Runtime/BlazeRuntime.php
@@ -18,8 +18,8 @@ use Livewire\Blaze\Debugger;
  */
 class BlazeRuntime
 {
-    // Lazily cached from config('view.compiled') on first access via __get.
-    // This ensures parallel-testing per-worker path overrides are respected.
+    // Tests and isolated rendering temporarily override this property.
+    // When it is null we always read the current view.compiled config.
     protected ?string $compiledPath = null;
 
     protected array $paths = [];
@@ -48,7 +48,7 @@ class BlazeRuntime
         }
 
         if (! file_exists($compiledPath) || filemtime($path) > filemtime($compiledPath)) {
-            $this->compiler->compile($path);
+            $this->getCompiler()->compile($path);
         }
 
         require $compiledPath;
@@ -243,7 +243,22 @@ class BlazeRuntime
 
     private function getCompiledPath(): string
     {
-        return $this->compiledPath ??= config('view.compiled');
+        return $this->compiledPath ?? config('view.compiled');
+    }
+
+    private function getCompiler(): Compiler
+    {
+        $compiler = app('blade.compiler');
+        $compiledPath = $this->getCompiledPath();
+        static $cachePath;
+
+        $cachePath ??= new \ReflectionProperty($compiler, 'cachePath');
+
+        if ($cachePath->getValue($compiler) !== $compiledPath) {
+            $cachePath->setValue($compiler, $compiledPath);
+        }
+
+        return $compiler;
     }
 
     /**

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -4,6 +4,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
 use Illuminate\View\Component;
 use Livewire\Blaze\Blaze;
 use Livewire\Blaze\BlazeManager;
@@ -93,3 +94,21 @@ test('folds and compiles the same component', function () {
         ['required' => true]
     );
 })->throwsNoExceptions();
+
+test('uses the current compiled view path after blaze runtime is resolved', function () {
+    Blaze::optimize()->in(__DIR__.'/fixtures/components');
+
+    app(BlazeRuntime::class);
+
+    $compiledPath = sys_get_temp_dir() . '/blaze-compiled-' . bin2hex(random_bytes(4));
+
+    File::ensureDirectoryExists($compiledPath);
+
+    config()->set('view.compiled', $compiledPath);
+
+    try {
+        expect(view('mix')->render())->toContain('<input');
+    } finally {
+        File::deleteDirectory($compiledPath);
+    }
+});


### PR DESCRIPTION
Fixes #177.

BlazeRuntime was caching `view.compiled` the first time `compiledPath` was read. In tenant setups that update the compiled view path after the runtime singleton has already been resolved, Blaze could keep compiling against the original cache directory instead of the tenant-scoped one.

This keeps the compiled path dynamic unless it is explicitly overridden, and makes sure the Blade compiler uses that current path before compiling a Blaze component.