### PR TITLE
Handle missing compiled Blaze views

### DIFF
--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -289,19 +289,13 @@ class BlazeManager
 
         $compiler = $engine->getCompiler();
         $compiled = $compiler->getCompiledPath($path);
+
         $expired = $compiler->isExpired($path);
+        $expired = $expired ? true : (new FrontMatter)->sourceContainsExpiredFoldedDependencies($compiled);
 
-        $isExpired = false;
+        $this->expiredMemo[$path] = $expired;
 
-        if (! $expired) {
-            $contents = file_get_contents($compiled);
-
-            $isExpired = (new FrontMatter)->sourceContainsExpiredFoldedDependencies($contents);
-        }
-
-        $this->expiredMemo[$path] = $isExpired;
-
-        return $isExpired;
+        return $expired;
     }
 
     /**

--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -276,12 +276,11 @@ class BlazeManager
     public function viewContainsExpiredFrontMatter($view): bool
     {
         $engine = $view->getEngine();
+        $path = $view->getPath();
 
         if (! $engine instanceof CompilerEngine) {
             return false;
         }
-
-        $path = $view->getPath();
 
         if (isset($this->expiredMemo[$path])) {
             return $this->expiredMemo[$path];
@@ -290,7 +289,7 @@ class BlazeManager
         $compiler = $engine->getCompiler();
         $compiled = $compiler->getCompiledPath($path);
 
-        $expired = $compiler->isExpired($path) ?: (new FrontMatter)->sourceContainsExpiredFoldedDependencies($compiled);
+        $expired = $compiler->isExpired($path) ? false : (new FrontMatter)->sourceContainsExpiredFoldedDependencies($compiled);
 
         return $this->expiredMemo[$path] = $expired;
     }

--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -290,12 +290,9 @@ class BlazeManager
         $compiler = $engine->getCompiler();
         $compiled = $compiler->getCompiledPath($path);
 
-        $expired = $compiler->isExpired($path);
-        $expired = $expired ? true : (new FrontMatter)->sourceContainsExpiredFoldedDependencies($compiled);
+        $expired = $compiler->isExpired($path) ?: (new FrontMatter)->sourceContainsExpiredFoldedDependencies($compiled);
 
-        $this->expiredMemo[$path] = $expired;
-
-        return $expired;
+        return $this->expiredMemo[$path] = $expired;
     }
 
     /**

--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -278,18 +278,17 @@ class BlazeManager
         $engine = $view->getEngine();
         $path = $view->getPath();
 
-        if (! $engine instanceof CompilerEngine) {
-            return false;
-        }
-
         if (isset($this->expiredMemo[$path])) {
             return $this->expiredMemo[$path];
         }
 
+        if (! $engine instanceof CompilerEngine) {
+            return $this->expiredMemo[$path] = false;
+        }
+
         $compiler = $engine->getCompiler();
         $compiled = $compiler->getCompiledPath($path);
-
-        $expired = $compiler->isExpired($path) ? false : (new FrontMatter)->sourceContainsExpiredFoldedDependencies($compiled);
+        $expired = $compiler->isExpired($path) ? false : (new FrontMatter)->containsExpiredFoldedDependencies($compiled);
 
         return $this->expiredMemo[$path] = $expired;
     }

--- a/src/FrontMatter.php
+++ b/src/FrontMatter.php
@@ -35,7 +35,7 @@ class FrontMatter
         $source = @file_get_contents($path);
         
         if ($source === false) {
-            return true;
+            return false;
         }
 
         $foldedComponents = $this->parseFromTemplate($source);

--- a/src/FrontMatter.php
+++ b/src/FrontMatter.php
@@ -30,7 +30,7 @@ class FrontMatter
     /**
      * Check if any folded component referenced in the compiled file has been modified.
      */
-    public function sourceContainsExpiredFoldedDependencies(string $path): bool
+    public function containsExpiredFoldedDependencies(string $path): bool
     {
         $source = @file_get_contents($path);
         

--- a/src/FrontMatter.php
+++ b/src/FrontMatter.php
@@ -28,10 +28,16 @@ class FrontMatter
     }
 
     /**
-     * Check if any folded component referenced in the source has been modified.
+     * Check if any folded component referenced in the compiled file has been modified.
      */
-    public function sourceContainsExpiredFoldedDependencies(string $source): bool
+    public function sourceContainsExpiredFoldedDependencies(string $path): bool
     {
+        $source = @file_get_contents($path);
+        
+        if ($source === false) {
+            return true;
+        }
+
         $foldedComponents = $this->parseFromTemplate($source);
 
         if (empty($foldedComponents)) {

--- a/tests/BlazeManagerTest.php
+++ b/tests/BlazeManagerTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
 use Livewire\Blaze\Blaze;
+use Livewire\Blaze\BlazeManager;
+
+beforeEach(fn () => Artisan::call('view:clear'));
 
 test('compile preserves php directives', function () {
     $input = '@php /* uncompiled */ @endphp';
@@ -26,4 +30,27 @@ test('compileForUnblaze does not restore raw blocks', function () {
     // compileForUnblaze should only store raw blocks, not restore them.
     // They will be restored in the parent compile() method.
     expect(Blaze::compileForUnblaze($input))->toBe('@__raw_block_0__@');
+});
+
+test('viewContainsExpiredFrontMatter returns true when folded component source is updated', function () {
+    $component = fixture_path('views/components/foldable/input.blade.php');
+    $modified = filemtime($component);
+    $manager = app(BlazeManager::class);
+    $view = view('blaze');
+
+    $view->render();
+    $manager->flushState();
+
+    touch($component, $modified + 10);
+
+    expect($manager->viewContainsExpiredFrontMatter($view))->toBeTrue();
+
+    touch($component, $modified);
+});
+
+test('viewContainsExpiredFrontMatter returns false when view isnt compiled', function () {
+    $manager = app(BlazeManager::class);
+    $view = view('blaze');
+
+    expect($manager->viewContainsExpiredFrontMatter($view))->toBeFalse();
 });


### PR DESCRIPTION
Handles potential race condition where compiled view file gets deleted between checking it via `$view->getExpired()` and `file_get_contents()` while checking its frontmatter.

+Refactor
+Tests for `viewContainsExpiredFrontMatter`

Fixes #175 