### PR TITLE
Always abort fold when `@aware` prop is dynamic, regardless of safe list

### DIFF
--- a/src/Folder/Folder.php
+++ b/src/Folder/Folder.php
@@ -104,7 +104,7 @@ class Folder
                 && isset($node->parentsAttributes[$prop])
                 && ! $node->parentsAttributes[$prop]->isStaticValue()
             ) {
-                $dynamicAttributes[$prop] = $node->parentsAttributes[$prop];
+                return false;
             }
         }
 

--- a/tests/Folder/FolderTest.php
+++ b/tests/Folder/FolderTest.php
@@ -238,6 +238,45 @@ test('folds components with static aware prop from parent', function () {
     expect($folded)->toBeInstanceOf(TextNode::class);
 });
 
+test('does not fold components with dynamic aware prop from parent even when listed in safe', function () {
+    $input = '<x-foldable.input-aware-safe />';
+
+    $node = app(Parser::class)->parse($input)[0];
+    $node->setParentsAttributes(
+        app(AttributeParser::class)->parse(':type="$type"')
+    );
+
+    $folded = app(Folder::class)->fold($node);
+
+    expect($folded)->toBeInstanceOf(ComponentNode::class);
+});
+
+test('folds components with aware prop listed in safe overridden by direct attribute', function () {
+    $input = '<x-foldable.input-aware-safe type="number" />';
+
+    $node = app(Parser::class)->parse($input)[0];
+    $node->setParentsAttributes(
+        app(AttributeParser::class)->parse(':type="$type"')
+    );
+
+    $folded = app(Folder::class)->fold($node);
+
+    expect($folded)->toBeInstanceOf(TextNode::class);
+});
+
+test('folds components with static aware prop listed in safe from parent', function () {
+    $input = '<x-foldable.input-aware-safe />';
+
+    $node = app(Parser::class)->parse($input)[0];
+    $node->setParentsAttributes(
+        app(AttributeParser::class)->parse(':type="true"')
+    );
+
+    $folded = app(Folder::class)->fold($node);
+
+    expect($folded)->toBeInstanceOf(TextNode::class);
+});
+
 test('does not fold components with no blaze directive', function () {
     $input = '<x-foldable.input-no-blaze />';
     

--- a/tests/Folder/FolderTest.php
+++ b/tests/Folder/FolderTest.php
@@ -238,7 +238,7 @@ test('folds components with static aware prop from parent', function () {
     expect($folded)->toBeInstanceOf(TextNode::class);
 });
 
-test('does not fold components with dynamic aware prop from parent even when listed in safe', function () {
+test('does not fold components if a dynamic prop comes from parent using aware even when marked as safe', function () {
     $input = '<x-foldable.input-aware-safe />';
 
     $node = app(Parser::class)->parse($input)[0];
@@ -251,26 +251,10 @@ test('does not fold components with dynamic aware prop from parent even when lis
     expect($folded)->toBeInstanceOf(ComponentNode::class);
 });
 
-test('folds components with aware prop listed in safe overridden by direct attribute', function () {
+test('folds components when a prop is passed directly even if aware is declared', function () {
     $input = '<x-foldable.input-aware-safe type="number" />';
 
     $node = app(Parser::class)->parse($input)[0];
-    $node->setParentsAttributes(
-        app(AttributeParser::class)->parse(':type="$type"')
-    );
-
-    $folded = app(Folder::class)->fold($node);
-
-    expect($folded)->toBeInstanceOf(TextNode::class);
-});
-
-test('folds components with static aware prop listed in safe from parent', function () {
-    $input = '<x-foldable.input-aware-safe />';
-
-    $node = app(Parser::class)->parse($input)[0];
-    $node->setParentsAttributes(
-        app(AttributeParser::class)->parse(':type="true"')
-    );
 
     $folded = app(Folder::class)->fold($node);
 

--- a/tests/fixtures/views/components/foldable/input-aware-safe.blade.php
+++ b/tests/fixtures/views/components/foldable/input-aware-safe.blade.php
@@ -1,0 +1,9 @@
+@blaze(fold: true, safe: ['type'])
+
+@aware(['type' => 'text'])
+
+@if ($type == 'number')
+    <input type="number">
+@else
+    <input type="text">
+@endif


### PR DESCRIPTION
# The Scenario

A Flux user wraps `<flux:select>` in an anonymous component that forwards a dynamic `:indicator`. They expect each `<flux:select.option>` to render a checkbox indicator when `multiple` is true. Instead, each option renders the default indicator. Replacing the dynamic value with a static `indicator="checkbox"` works, so the bug only happens when `:indicator` is supplied dynamically by the parent.

<img width="1060" height="466" alt="Screenshot 2026-05-18 at 01 10 19PM@2x" src="https://github.com/user-attachments/assets/feff46b6-8fdf-4dce-8bfc-43cf1b70704a" />

```blade
<flux:select
    variant="listbox"
    :multiple="$multiple"
    :indicator="$multiple ? 'checkbox' : null"
>
    @foreach($items as $item)
        <flux:select.option :value="$item->id">{{ $item->name }}</flux:select.option>
    @endforeach
</flux:select>
```

# The Problem

Flux's `select/option/index.blade.php` lists `indicator` in both `@aware` and `safe:`:

```blade
@blaze(fold: true, safe: ['filterable', 'indicator', 'loading'])
@aware(['variant', 'indicator'])
```

v1.0.12 added a guard so that an `@aware` prop supplied dynamically by the parent aborts the fold. But the guard runs the prop through the same `$unsafe` lookup that `safe:` subtracts from, so any prop listed in both is silently re-permitted and the fold proceeds. The `@aware` runtime lookup is then compiled away and the child renders with the prop's default.

# The Solution

Abort the fold immediately when an `@aware` prop is supplied dynamically by the parent, without consulting `safe:`. A `safe:` declaration is a promise about dynamic values passed on the component itself; it cannot apply to values that enter via `@aware`, because folding eliminates the `@aware` lookup entirely.

<img width="1070" height="468" alt="Screenshot 2026-05-18 at 01 13 08PM@2x" src="https://github.com/user-attachments/assets/91a4b447-b1c9-4711-8ac1-b52b9d131eb8" />

Fixes livewire/flux#2613