### PR TITLE
Respect blaze directive compile: false override

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -62,6 +62,10 @@ class Compiler
      */
     protected function shouldCompile(ComponentSource $source): bool
     {
+        if ($source->directives->blaze('compile') === false) {
+            return false;
+        }
+
         if ($source->directives->blaze()) {
             return true;
         }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -62,12 +62,8 @@ class Compiler
      */
     protected function shouldCompile(ComponentSource $source): bool
     {
-        if ($source->directives->blaze('compile') === false) {
-            return false;
-        }
-
         if ($source->directives->blaze()) {
-            return true;
+            return $source->directives->blaze('compile') ?? true;
         }
 
         return $this->config->shouldCompile($source->path)

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -15,7 +15,17 @@ class Utils
      */
     public static function parseBlazeDirective(string $expression): array
     {
-        return BlazeDirective::parseParameters($expression);
+        $params = BlazeDirective::parseParameters($expression);
+
+        if ($params['compile'] === false && $params['memo'] === true) {
+            throw new \InvalidArgumentException('Cannot set `memo: true` with `compile: false` in @blaze directive.');
+        }
+
+        if ($params['compile'] === false && $params['fold'] === true) {
+            throw new \InvalidArgumentException('Cannot set `fold: true` with `compile: false` in @blaze directive.');
+        }
+
+        return $params;
     }
 
     /**

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -17,11 +17,11 @@ class Utils
     {
         $params = BlazeDirective::parseParameters($expression);
 
-        if ($params['compile'] === false && $params['memo'] === true) {
+        if (data_get($params, 'compile', true) === false && data_get($params, 'memo', false) === true) {
             throw new \InvalidArgumentException('Cannot set `memo: true` with `compile: false` in @blaze directive.');
         }
 
-        if ($params['compile'] === false && $params['fold'] === true) {
+        if (data_get($params, 'compile', true) === false && data_get($params, 'fold', false) === true) {
             throw new \InvalidArgumentException('Cannot set `fold: true` with `compile: false` in @blaze directive.');
         }
 

--- a/tests/Compiler/CompilerTest.php
+++ b/tests/Compiler/CompilerTest.php
@@ -2,6 +2,8 @@
 
 use Livewire\Blaze\Parser\Parser;
 use Livewire\Blaze\Compiler\Compiler;
+use Livewire\Blaze\Config;
+use Livewire\Blaze\Parser\Nodes\ComponentNode;
 use Livewire\Blaze\Support\Utils;
 
 test('compiles self-closing components', function () {
@@ -76,4 +78,15 @@ test('compiles delegate components', function () {
         '<?php $__blaze->popData(); ?> ',
         '<?php unset($__resolved) ?>',
     ]));
+});
+
+test('does not compile components with blaze directive override set to false', function () {
+    $input = '<x-compile-false />';
+
+    app(Config::class)->add(fixture_path('views/components'));
+
+    $node = app(Parser::class)->parse($input)[0];
+    $compiled = app(Compiler::class)->compile($node);
+
+    expect($compiled)->toBeInstanceOf(ComponentNode::class);
 });

--- a/tests/Folder/FolderTest.php
+++ b/tests/Folder/FolderTest.php
@@ -247,6 +247,18 @@ test('does not fold components with no blaze directive', function () {
     expect($folded)->toBeInstanceOf(ComponentNode::class);
 });
 
+test('does not fold components with blaze directive override set to false', function () {
+    $input = '<x-foldable.fold-false />';
+
+    app(Config::class)->add(fixture_path('views/components/foldable'), fold: true);
+
+    $node = app(Parser::class)->parse($input)[0];
+    $compiled = app(Folder::class)->fold($node);
+
+    expect($compiled)->toBeInstanceOf(ComponentNode::class);
+});
+
+
 test('folds components with no blaze directive if enabled in config', function () {
     $input = '<x-foldable.input-no-blaze />';
 

--- a/tests/Memoizer/MemoizerTest.php
+++ b/tests/Memoizer/MemoizerTest.php
@@ -65,3 +65,14 @@ test('memoizes components without blaze directive if enabled in config', functio
 
     expect($memoized)->toBeInstanceOf(TextNode::class);
 });
+
+test('does not memoize components with blaze directive override set to false', function () {
+    $input = '<x-memoizable.memo-false />';
+
+    app(Config::class)->add(fixture_path('views/components/memoizable'), memo: true);
+
+    $node = app(Parser::class)->parse($input)[0];
+    $compiled = app(Memoizer::class)->memoize($node);
+
+    expect($compiled)->toBeInstanceOf(ComponentNode::class);
+});

--- a/tests/fixtures/views/components/compile-false.blade.php
+++ b/tests/fixtures/views/components/compile-false.blade.php
@@ -1,0 +1,3 @@
+@blaze(compile: false)
+
+<div></div>

--- a/tests/fixtures/views/components/foldable/fold-false.blade.php
+++ b/tests/fixtures/views/components/foldable/fold-false.blade.php
@@ -1,0 +1,3 @@
+@blaze(fold: false)
+
+<div></div>

--- a/tests/fixtures/views/components/memoizable/memo-false.blade.php
+++ b/tests/fixtures/views/components/memoizable/memo-false.blade.php
@@ -1,0 +1,3 @@
+@blaze(memo: false)
+
+<div></div>


### PR DESCRIPTION
# The scenario

A component with a blaze directive with `compile: false` will not override `Blaze::optimize()` config.

```php
// app/Providers/AppServiceProvider.php

Blaze::optimize()->add(resource_path('views/components'));
```

```blade
<!-- resources/views/components/input.blade.php -->

@blaze(compile: false)
```

The above component will compile.

# The problem

We are only checking if the `@blaze` directive is present to decide whether to compile a component.

# The solution

Check for `compile === false` first.

Fixes #183 
