### PR TITLE
Preserve literal static attributes when folding

### DIFF
--- a/src/Parser/Attribute.php
+++ b/src/Parser/Attribute.php
@@ -31,28 +31,43 @@ class Attribute
      */
     public function isStaticValue(): bool
     {
-        return $this->dynamic === false || in_array($this->value, ['true', 'false', 'null'], true);
+        return $this->dynamic === false || $this->hasConstantDynamicValue();
     }
 
+    /**
+     * Resolve the compile time value of this attribute.
+     */
     public function getStaticValue(): mixed
     {
-        if (! $this->isStaticValue()) {
+        if ($this->hasConstantDynamicValue()) {
+            return $this->getConstantValue();
+        }
+            
+        if ($this->dynamic) {
             throw new \LogicException("Cannot get static value of dynamic attribute '{$this->name}'.");
         }
 
-        if ($this->valueless) {
-            return true;
-        }
+        return $this->value;
+    }
 
-        if (! $this->bound()) {
-            return $this->value;
-        }
+    /**
+     * Check if this attribute is dynamic and has a constant value (true, false, or null).
+     */
+    protected function hasConstantDynamicValue(): bool
+    {
+        return $this->dynamic && in_array($this->value, ['true', 'false', 'null'], true);
+    }
 
+    /**
+     * Resolve the constant value of this attribute (true, false, or null).
+     */
+    protected function getConstantValue()
+    {
         return match ($this->value) {
             'true' => true,
             'false' => false,
             'null' => null,
-            default => $this->value,
+            default => throw new \LogicException("Invalid constant value '{$this->value}'."),
         };
     }
 }

--- a/src/Parser/Attribute.php
+++ b/src/Parser/Attribute.php
@@ -40,6 +40,14 @@ class Attribute
             throw new \LogicException("Cannot get static value of dynamic attribute '{$this->name}'.");
         }
 
+        if ($this->valueless) {
+            return true;
+        }
+
+        if (! $this->bound()) {
+            return $this->value;
+        }
+
         return match ($this->value) {
             'true' => true,
             'false' => false,

--- a/src/Support/AttributeParser.php
+++ b/src/Support/AttributeParser.php
@@ -49,7 +49,7 @@ class AttributeParser
             $valueless = is_null($value);
 
             if ($valueless) {
-                $value = 'true';
+                $value = true;
             }
 
             $quotes = '';

--- a/tests/ComparisonTest.php
+++ b/tests/ComparisonTest.php
@@ -58,6 +58,13 @@ test('foldable boolean attributes', fn () => compare(<<<'BLADE'
     ['readonly' => false],
 ));
 
+test('foldable literal string attributes matching PHP constants', fn () => compare(<<<'BLADE'
+    <x-foldable.input value="true" />
+    <x-foldable.input value="false" />
+    <x-foldable.input value="null" />
+    BLADE
+));
+
 test('same component in a slot doesnt affect parents attributes', fn () => compare(<<<'BLADE'
     <x-card>
         <x-card x-data>

--- a/tests/Parser/AttributeTest.php
+++ b/tests/Parser/AttributeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Livewire\Blaze\Support\AttributeParser;
+
+test('getStaticValue returns constatnts for dynamic constant values', function () {
+    $attribute = app(AttributeParser::class)->parse(':foo="true"')['foo'];
+
+    expect($attribute->isStaticValue())->toBeTrue();
+    expect($attribute->getStaticValue())->toBeTrue();
+});
+
+test('getStaticValue returns strings for static constant values', function () {
+    $attribute = app(AttributeParser::class)->parse('foo="true"')['foo'];
+
+    expect($attribute->isStaticValue())->toBeTrue();
+    expect($attribute->getStaticValue())->toBe('true');
+});
+
+test('getStaticValue returns true for valueless attributes', function () {
+    $attribute = app(AttributeParser::class)->parse('foo')['foo'];
+
+    expect($attribute->isStaticValue())->toBeTrue();
+    expect($attribute->getStaticValue())->toBeTrue();
+});
+
+test('getStaticValue throws for dynamic attributes', function () {
+    $attribute = app(AttributeParser::class)->parse(':foo="$bar"')['foo'];
+
+    $attribute->getStaticValue();
+})->throws(LogicException::class);

--- a/tests/Support/AttributeParserTest.php
+++ b/tests/Support/AttributeParserTest.php
@@ -30,7 +30,7 @@ test('parses attributes without value', function () {
     expect($attrs)->toHaveKey('disabled');
     expect($attrs['disabled'])
         ->name->toBe('disabled')
-        ->value->toBe('true')
+        ->value->toBeTrue()
         ->valueless->toBeTrue()
         ->dynamic->toBeFalse()
         ->quotes->toBe('');


### PR DESCRIPTION
# The Scenario

A user has a Flux radio group bound to a nullable boolean property using Livewire's `.boolean` modifier. Without Blaze, selecting the `false` radio option updates the property to `false` as expected. With Blaze enabled, selecting the `false` option still behaves as truthy, so the property appears to always be `true`.

```blade
<flux:radio.group wire:model.boolean.live="testBoolean" variant="cards">
    <flux:radio value="true" label="here is true" />
    <flux:radio value="false" label="here is false" />
</flux:radio.group>
```

# The Problem

Blaze folding resolves static attribute values through `Attribute::getStaticValue()` before rendering folded output. That method was converting any static `true`, `false`, or `null` string into the equivalent PHP value, even when the attribute was not bound.

That meant `value="false"` became boolean `false` during folded rendering and was omitted by the attribute bag. Flux radio elements generate a fallback value when no `value` attribute is present, so the `false` option ended up with a generated non-empty string instead of `"false"`.

Meanwhile, `value="true"` became boolean `true` and rendered as `value="value"`. Livewire's `.boolean` modifier therefore received non-empty strings for both options, causing the `false` option to behave as truthy.

# The Solution

This changes folded static attribute resolution so unbound literal values are kept as strings instead of being treated as PHP constants. Now `value="false"` stays `"false"` during folding and renders the same way it does in Blade.

Fixes livewire/flux#2651