### PR TITLE
Exclude Blaze scope variables from Volt fragment arguments

### DIFF
--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -166,6 +166,30 @@ class BlazeManager
     }
 
     /**
+     * Exclude Blaze's internal variables from Volt fragment component arguments.
+     *
+     * Volt compiles @volt fragments (used in Laravel Folio pages) into a Livewire
+     * mount call that captures the surrounding template scope via get_defined_vars().
+     * Blaze introduces variables into that scope ($__blaze and call-site temporaries)
+     * that would otherwise be forwarded to Livewire, serialized into the component
+     * snapshot, and corrupt its checksum on subsequent requests.
+     */
+    public function excludeBlazeVariablesFromVoltFragments(string $template): string
+    {
+        $needle = 'ExtractFragments::componentArguments([...get_defined_vars()';
+
+        if (! str_contains($template, $needle)) {
+            return $template;
+        }
+
+        return str_replace(
+            $needle,
+            'ExtractFragments::componentArguments([...\Livewire\Blaze\Support\Utils::exceptBlazeVariables(get_defined_vars())',
+            $template,
+        );
+    }
+
+    /**
      * Compile a template for debug-only mode (Blaze disabled).
      *
      * Parses the template to find components and wraps them with timer

--- a/src/BlazeServiceProvider.php
+++ b/src/BlazeServiceProvider.php
@@ -156,6 +156,8 @@ class BlazeServiceProvider extends ServiceProvider
                 return $input;
             }
 
+            $input = $blaze->excludeBlazeVariablesFromVoltFragments($input);
+
             if ($blaze->isDisabled()) {
                 if ($blaze->isDebugging()) {
                     return $blaze->compileForDebug($input, $path);

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -35,4 +35,16 @@ class Utils
     {
         return hash('xxh128', 'v2' . $componentPath);
     }
+
+    /**
+     * Remove Blaze's internal template-scope variables (the shared runtime and
+     * compiled call-site temporaries) from a get_defined_vars() capture.
+     */
+    public static function exceptBlazeVariables(array $variables): array
+    {
+        return array_filter($variables, function ($key) {
+            return ! str_starts_with($key, '__blaze')
+                && ! preg_match('/^__(?:attrs|slots)(?:Stack)?[0-9a-f]{32}$/', $key);
+        }, ARRAY_FILTER_USE_KEY);
+    }
 }

--- a/tests/BlazeManagerTest.php
+++ b/tests/BlazeManagerTest.php
@@ -54,3 +54,21 @@ test('viewContainsExpiredFrontMatter returns false when view isnt compiled', fun
 
     expect($manager->viewContainsExpiredFrontMatter($view))->toBeFalse();
 });
+
+test('blaze variables are excluded from volt fragment component arguments', function () {
+    // Volt compiles @volt fragments into a Livewire mount call that captures the
+    // entire template scope via get_defined_vars(). Blaze's runtime and call-site
+    // temporaries must be filtered out of that capture, otherwise they end up
+    // serialized into the Livewire snapshot and corrupt its checksum...
+    $input = '@livewire("volt-anonymous-fragment-abc123", Livewire\Volt\Precompilers\ExtractFragments::componentArguments([...get_defined_vars(), ...array()]))';
+
+    $compiled = app('blade.compiler')->compileString($input);
+
+    expect($compiled)->toContain('ExtractFragments::componentArguments([...\Livewire\Blaze\Support\Utils::exceptBlazeVariables(get_defined_vars()), ...array()])');
+});
+
+test('get_defined_vars is left untouched outside volt fragment component arguments', function () {
+    $input = '<?php $vars = get_defined_vars(); ?>';
+
+    expect(Blaze::excludeBlazeVariablesFromVoltFragments($input))->toBe($input);
+});

--- a/tests/Support/UtilsTest.php
+++ b/tests/Support/UtilsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Livewire\Blaze\Support\Utils;
+
+test('exceptBlazeVariables removes blaze internals and keeps user variables', function () {
+    $hash = Utils::hash('components/layout.blade.php');
+
+    $variables = [
+        'message' => 'Hello',
+        'count' => 1,
+        '__blaze' => new stdClass,
+        '__blazeViewName' => 'layout',
+        '__attrs'.$hash => ['title' => 'Test'],
+        '__slots'.$hash => [],
+        '__attrsStack'.$hash => [],
+        '__slotsStack'.$hash => [],
+    ];
+
+    expect(Utils::exceptBlazeVariables($variables))->toBe([
+        'message' => 'Hello',
+        'count' => 1,
+    ]);
+});


### PR DESCRIPTION
Fixes #187

## The problem

Using Blaze on an app with a Laravel Folio page that embeds a Volt component via `@volt` throws `CorruptComponentPayloadException` on any interaction with the component.

## Root cause

Volt compiles `@volt` fragments into a Livewire mount call that captures the entire surrounding template scope:

```php
ExtractFragments::componentArguments([...get_defined_vars(), ...])
```

Volt filters out the framework variables it knows about (`__env`, `__data`, `errors`, etc.), but Blaze introduces new variables into template scope that aren't on that list:

- `$__blaze` — the shared runtime, injected into every view
- `$__attrs{hash}` / `$__slots{hash}` (and their stacks) — call-site temporaries emitted around optimized component calls (e.g. a layout component wrapping the fragment)

Volt forwards these to Livewire as component arguments. Since they don't match any public property, Livewire stores them as HTML attributes in the snapshot memo. The serialized runtime contains empty objects (`{}`) that decode to `[]` on the next request, so the re-encoded snapshot no longer matches its checksum — and Livewire throws the corrupt payload exception.

This also explains why scoping Blaze to specific directories didn't help (`$__blaze` is injected into every view while Blaze is enabled) and why only disabling Blaze entirely worked.

## The fix

When Blaze's pre-compilation hook sees Volt's generated scope capture (Volt's precompiler always runs first, since Blaze registers its hook after the app is booted), it wraps `get_defined_vars()` so Blaze's internal variables are filtered out before Volt ever sees them:

```php
ExtractFragments::componentArguments([...\Livewire\Blaze\Support\Utils::exceptBlazeVariables(get_defined_vars()), ...])
```

User variables in scope (e.g. data passed from Folio's `render()`) still flow through exactly as before.

## Verification

Reproduced against a fresh Laravel 13 app (Livewire 4.3.3, Volt 1.10.5, Folio 1.1) with a Folio page embedding a `@volt` counter inside a Blaze-optimized layout component:

- Before: `POST /livewire/update` → 500 `CorruptComponentPayloadException`
- After: `POST /livewire/update` → 200, counter increments, and the snapshot memo is byte-for-byte identical in shape to running with Blaze disabled (including intentionally captured scope variables like Folio `render()` data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)