### PR TITLE
Fix @aware resolution when folding across template boundaries

### DIFF
--- a/src/BladeRenderer.php
+++ b/src/BladeRenderer.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Component;
 use Illuminate\View\ComponentSlot;
+use Livewire\Blaze\Exceptions\StaleUnblazeCacheException;
 use Livewire\Blaze\Parser\Attribute;
 use Livewire\Blaze\Parser\Nodes\ComponentNode;
 use Livewire\Blaze\Parser\Nodes\SlotNode;
@@ -139,7 +140,16 @@ class BladeRenderer
             $restoreRuntime();
         }
 
-        $result = Unblaze::replaceUnblazePrecompiledDirectives($result);
+        try {
+            $result = Unblaze::replaceUnblazePrecompiledDirectives($result);
+        } catch (StaleUnblazeCacheException $th) {
+            // The token came from a compiled file cached by an older version of Blaze.
+            // Delete the cache so it gets regenerated on the next compile, and let
+            // the fold be aborted so the component renders normally this time...
+            $this->deleteTemporaryCacheDirectory();
+
+            throw $th;
+        }
 
         return $result;
     }

--- a/src/BlazeManager.php
+++ b/src/BlazeManager.php
@@ -21,6 +21,7 @@ use Livewire\Blaze\Parser\Walker;
 use Livewire\Blaze\Support\Directives;
 use Livewire\Blaze\Support\ComponentSource;
 use Livewire\Blaze\Parser\Nodes\SlotNode;
+use Livewire\Blaze\Parser\Nodes\TextNode;
 use Livewire\Blaze\Support\AttributeParser;
 
 class BlazeManager
@@ -79,6 +80,10 @@ class BlazeManager
         $ast = $this->walker->walk(
             nodes: $this->parser->parse($clean),
             preCallback: function ($node) use (&$dataStack) {
+                if ($node instanceof ComponentNode) {
+                    $node->hasComponentAncestors = $dataStack !== [];
+                }
+
                 if ($node instanceof ComponentNode && $node->children) {
                     $dataStack[] = $node->attributes;
 
@@ -417,10 +422,58 @@ class BlazeManager
                 if ($this->hasAwareDescendant($child)) {
                     return true;
                 }
+
+                // Components rendered from within the child's own template aren't
+                // lexically visible here, so we need to scan its source too...
+                if ($this->templateHasAwareComponents($source)) {
+                    return true;
+                }
             } elseif ($child instanceof SlotNode) {
                 if ($this->hasAwareDescendant($child)) {
                     return true;
                 }
+            } elseif ($child instanceof TextNode) {
+                // Included partials can render components that use @aware...
+                if (preg_match('/@include|@each/', $child->content)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Recursively check if a component's template renders components that use @aware.
+     */
+    protected function templateHasAwareComponents(ComponentSource $source, array &$visited = []): bool
+    {
+        if (! $source->exists() || isset($visited[$source->path])) {
+            return false;
+        }
+
+        $visited[$source->path] = true;
+
+        $content = $source->content();
+
+        // Includes and dynamically resolved components can't be inspected statically...
+        if (preg_match('/@include|@each|delegate-component|dynamic-component/', $content)) {
+            return true;
+        }
+
+        preg_match_all('/<(x-|x:|flux:)([\w.-]+)/', $content, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $name = $match[1] === 'flux:' ? 'flux::' . $match[2] : $match[2];
+
+            $childSource = ComponentSource::for($this->blade->componentNameToPath($name));
+
+            if ($childSource->directives->has('aware')) {
+                return true;
+            }
+
+            if ($this->templateHasAwareComponents($childSource, $visited)) {
+                return true;
             }
         }
 

--- a/src/Exceptions/StaleUnblazeCacheException.php
+++ b/src/Exceptions/StaleUnblazeCacheException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Livewire\Blaze\Exceptions;
+
+/**
+ * Thrown when a cached compiled file references an @unblaze token whose
+ * replacement content is unknown (e.g. it was cached by an older version
+ * of Blaze that only stored replacements in memory).
+ */
+class StaleUnblazeCacheException extends \Exception
+{
+    public function __construct(string $token)
+    {
+        parent::__construct("Unknown @unblaze token [{$token}] found in a cached compiled file.");
+    }
+}

--- a/src/Folder/Folder.php
+++ b/src/Folder/Folder.php
@@ -106,6 +106,17 @@ class Folder
             ) {
                 $dynamicAttributes[$prop] = $node->parentsAttributes[$prop];
             }
+
+            // When an @aware prop isn't resolvable from the template itself, the real
+            // parent is only known at runtime — the template may be rendered inside
+            // another component through an @include or a slot — so folding here
+            // would bake in the wrong value...
+            if (! isset($node->attributes[$prop])
+                && ! isset($node->parentsAttributes[$prop])
+                && ! $node->hasComponentAncestors
+            ) {
+                return false;
+            }
         }
 
         if (array_key_exists('attributes', $dynamicAttributes)) {

--- a/src/Parser/Nodes/ComponentNode.php
+++ b/src/Parser/Nodes/ComponentNode.php
@@ -10,6 +10,9 @@ class ComponentNode extends Node
     /** Pre-computed by the Walker before children are compiled to TextNodes. */
     public bool $hasAwareDescendants = false;
 
+    /** Whether this node is nested inside another component in the same template. */
+    public bool $hasComponentAncestors = false;
+
     public function __construct(
         public string $name,
         public string $prefix,

--- a/src/Unblaze.php
+++ b/src/Unblaze.php
@@ -3,6 +3,7 @@
 namespace Livewire\Blaze;
 
 use Livewire\Blaze\Compiler\DirectiveCompiler;
+use Livewire\Blaze\Exceptions\StaleUnblazeCacheException;
 use Illuminate\Support\Str;
 
 /**
@@ -20,6 +21,14 @@ class Unblaze
     public static function storeScope($token, $scope = [])
     {
         static::$unblazeScopes[$token] = $scope;
+    }
+
+    /**
+     * Store the original template content for an @unblaze token.
+     */
+    public static function storeReplacement($token, $content)
+    {
+        static::$unblazeReplacements[$token] = $content;
     }
 
     /**
@@ -57,8 +66,13 @@ class Unblaze
 
             static::$unblazeReplacements[$token] = $innerContent;
 
+            // The replacement is also stored from within the compiled file itself (base64
+            // encoded so it's opaque to later compilation passes) because the file is
+            // cached on disk and may be reused by a process where the in-memory
+            // replacement stored above no longer exists...
             return ''
                 . '[STARTCOMPILEDUNBLAZE:'.$token.']'
+                . '<'.'?php \Livewire\Blaze\Unblaze::storeReplacement("'.$token.'", base64_decode(\''.base64_encode($innerContent).'\')) ?>'
                 . '<'.'?php \Livewire\Blaze\Unblaze::storeScope("'.$token.'", '.$expression.') ?>'
                 . '[ENDCOMPILEDUNBLAZE:'.$token.']';
         }, $result);
@@ -81,6 +95,10 @@ class Unblaze
                 // based on the surrounding content and now we'll reapply it here.
                 if ($trim = Str::match('/:(ltrim|rtrim|trim)$/', $token)) {
                     $token = substr($token, 0, -(strlen($trim) + 1));
+                }
+
+                if (! array_key_exists($token, static::$unblazeReplacements)) {
+                    throw new StaleUnblazeCacheException($token);
                 }
 
                 $innerContent = Blaze::compileForUnblaze(

--- a/tests/ComparisonTest.php
+++ b/tests/ComparisonTest.php
@@ -52,6 +52,20 @@ test('foldable aware default', fn () => compare(<<<'BLADE'
     BLADE
 ));
 
+test('foldable aware through include partial', fn () => compare(<<<'BLADE'
+    <x-foldable.wrapper type="number">
+        @include('partials.aware-input')
+    </x-foldable.wrapper>
+    BLADE
+));
+
+test('foldable aware through nested component', fn () => compare(<<<'BLADE'
+    <x-foldable.wrapper type="number">
+        <x-aware-input-wrapper />
+    </x-foldable.wrapper>
+    BLADE
+));
+
 test('foldable boolean attributes', fn () => compare(<<<'BLADE'
     <x-foldable.input :readonly="$readonly" />
     BLADE,

--- a/tests/FluxProTest.php
+++ b/tests/FluxProTest.php
@@ -34,6 +34,20 @@ test('listbox', fn () => compare(<<<'BLADE'
     BLADE
 ));
 
+test('listbox with options emitted from an include partial', fn () => compare(<<<'BLADE'
+    <flux:select variant="listbox" searchable placeholder="Choose...">
+        @include('partials.listbox-options')
+    </flux:select>
+    BLADE
+));
+
+test('listbox with options emitted from a nested component', fn () => compare(<<<'BLADE'
+    <flux:select variant="listbox" searchable placeholder="Choose...">
+        <x-category-options />
+    </flux:select>
+    BLADE
+));
+
 test('chart', fn () => compare(<<<'BLADE'
     <flux:chart wire:model="data" class="w-full aspect-2/1">
         <flux:chart.viewport class="size-full">

--- a/tests/Folder/FolderTest.php
+++ b/tests/Folder/FolderTest.php
@@ -238,6 +238,26 @@ test('folds components with static aware prop from parent', function () {
     expect($folded)->toBeInstanceOf(TextNode::class);
 });
 
+test('does not fold components with unresolvable aware props at the template root', function () {
+    // The template may be rendered inside another component at runtime
+    // (through an @include or a slot), so the aware value is unknowable here...
+    $input = '<x-foldable.input-aware />';
+
+    $node = app(Parser::class)->parse($input)[0];
+    $folded = app(Folder::class)->fold($node);
+
+    expect($folded)->toBeInstanceOf(ComponentNode::class);
+});
+
+test('folds components with aware props at the template root when provided directly', function () {
+    $input = '<x-foldable.input-aware type="number" />';
+
+    $node = app(Parser::class)->parse($input)[0];
+    $folded = app(Folder::class)->fold($node);
+
+    expect($folded)->toBeInstanceOf(TextNode::class);
+});
+
 test('does not fold components with no blaze directive', function () {
     $input = '<x-foldable.input-no-blaze />';
     

--- a/tests/Folder/UnblazeTest.php
+++ b/tests/Folder/UnblazeTest.php
@@ -38,6 +38,25 @@ test('compiles nested unblaze blocks', function () {
     );
 });
 
+test('compiles unblaze blocks when the temporary compiled file was cached by a previous process', function () {
+    $input = '<x-foldable.input-unblaze name="address" />';
+
+    $fold = function () use ($input) {
+        $node = app(Parser::class)->parse($input)[0];
+
+        return (new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input-unblaze.blade.php')), app(BladeRenderer::class), app(BladeService::class)))->fold();
+    };
+
+    $first = $fold();
+
+    // The temporary compiled file persists on disk between processes, but the
+    // unblaze replacements are stored in memory, so we flush them here to
+    // simulate a fold happening in a fresh process reusing the cache...
+    \Livewire\Blaze\Unblaze::flushState();
+
+    expect($fold())->toBe($first);
+});
+
 test('folds dynamic attributes used inside unblaze directive', function () {
     $input = '<x-foldable.input-unblaze :name="$field" />';
 

--- a/tests/fixtures/views/components/aware-input-wrapper.blade.php
+++ b/tests/fixtures/views/components/aware-input-wrapper.blade.php
@@ -1,0 +1,1 @@
+<x-foldable.input-aware />

--- a/tests/fixtures/views/components/category-options.blade.php
+++ b/tests/fixtures/views/components/category-options.blade.php
@@ -1,0 +1,3 @@
+<flux:select.option>Photography</flux:select.option>
+<flux:select.option>Design services</flux:select.option>
+<flux:select.option.create wire:click="startCreate">Create new</flux:select.option.create>

--- a/tests/fixtures/views/partials/aware-input.blade.php
+++ b/tests/fixtures/views/partials/aware-input.blade.php
@@ -1,0 +1,1 @@
+<x-foldable.input-aware />

--- a/tests/fixtures/views/partials/listbox-options.blade.php
+++ b/tests/fixtures/views/partials/listbox-options.blade.php
@@ -1,0 +1,3 @@
+<flux:select.option>Photography</flux:select.option>
+<flux:select.option>Design services</flux:select.option>
+<flux:select.option.create wire:click="startCreate">Create new</flux:select.option.create>


### PR DESCRIPTION
Fixes #186

## Root cause

Two separate bugs, both surfaced in #186:

**1. Folding bakes in wrong `@aware` values across template boundaries (the actual `<flux:select>` crash).**

When a foldable component that consumes `@aware` props sits at the root of a template — i.e. it's rendered through an `@include` partial or from a nested component's view — its real parent only exists at runtime. The folder resolved `@aware` lexically, found nothing, and baked in the prop defaults.

Concretely: `<flux:select.option>` declares `@aware(['variant', 'indicator'])`. Rendered through a partial inside `<flux:select variant="listbox">`, it folded to the *default* variant's native `<option>` markup instead of the listbox's `<ui-option>` markup. flux.js then finds no `& > ui-option` children in the listbox, treats the list as empty, and hits `create._activatable.activate(true)` in a state it never expects — the uncaught TypeError kills init for every select on the page. This matches the reporter's repro matrix exactly (inline children fold correctly because the parent is lexically visible; slot/include boundaries crash).

**2. The temporary fold cache goes stale across processes (`Undefined array key` at `Unblaze.php:87`).**

Since #116 the temporary fold cache persists between compiles, but `Unblaze::$unblazeReplacements` only ever lived in memory in the process that compiled the file. Any other process reusing a cached compiled file (with `[STARTCOMPILEDUNBLAZE:…]` tokens baked in) missed the lookup, logged the undefined key warning the reporter found, and silently aborted the fold.

## Fix

- The folder no longer folds a component whose `@aware` props can't be resolved from the template itself (not passed directly, no value from a lexically visible parent, and no component ancestors in the template) — it renders normally and `@aware` resolves at runtime.
- `hasAwareDescendant()` now also detects `@aware` consumers hiding behind `@include`/`@each` and nested component templates (recursive source scan), so folded parents still push their data for that runtime lookup.
- `@unblaze` replacement content is now stored from within the compiled file itself (base64-encoded), so any process that renders a cached file repopulates the replacement map. Stale files from older versions purge the temp cache and abort the fold gracefully once.

## Tests

- `ComparisonTest`: `@aware` through an include partial and through a nested component (both fail on main, byte-identical to Blade after the fix).
- `FluxProTest`: the exact #186 scenario — `<flux:select variant="listbox" searchable>` with `flux:select.option` + `flux:select.option.create` emitted from an `@include` and from a nested component.
- `FolderTest`: unfoldable at template root with unresolvable `@aware`; still folds when the prop is passed directly.
- `UnblazeTest`: fold succeeds when the temp compiled file was cached by a previous process (fails on main with the reporter's exact `Unblaze.php:87` error).

Full suite: 220 passed (including flux + flux-pro comparison suites run locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)