### PR TITLE
Fix double escaping in delegate component

### DIFF
--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -162,7 +162,7 @@ class Compiler
         $functionName = '(\'' . ($this->manager->isFolding() ? '__' : '_') . '\' . $__resolved)';
         
         $output = '<' . '?php $__resolved = $__blaze->resolve(' . $componentName . '); ?>' . "\n";
-        $output .= '<' . '?php $__delegatedData = $__blaze->unescapeAttributes($attributes->all()); ?>' . "\n";
+        $output .= '<' . '?php $__delegatedData = $__blaze->unescapeAttributes($attributes->getAttributes()); ?>' . "\n";
         $output .= '<' . '?php $__blaze->pushData($__delegatedData); ?>' . "\n";
         $output .= '<' . '?php if ($__resolved !== false): ?>' . "\n";
 

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -162,11 +162,12 @@ class Compiler
         $functionName = '(\'' . ($this->manager->isFolding() ? '__' : '_') . '\' . $__resolved)';
         
         $output = '<' . '?php $__resolved = $__blaze->resolve(' . $componentName . '); ?>' . "\n";
-        $output .= '<' . '?php $__blaze->pushData($attributes->all()); ?>' . "\n";
+        $output .= '<' . '?php $__delegatedData = $__blaze->unescapeAttributes($attributes->all()); ?>' . "\n";
+        $output .= '<' . '?php $__blaze->pushData($__delegatedData); ?>' . "\n";
         $output .= '<' . '?php if ($__resolved !== false): ?>' . "\n";
 
         if ($node->selfClosing) {
-            $output .= '<' . '?php ' . $functionName . '($__blaze, $attributes->all(), $__blaze->mergedComponentSlots(), [], [], $__this ?? (isset($this) ? $this : null)); ?>' . "\n";
+            $output .= '<' . '?php ' . $functionName . '($__blaze, $__delegatedData, $__blaze->mergedComponentSlots(), [], [], $__this ?? (isset($this) ? $this : null)); ?>' . "\n";
         } else {
             $hash = Utils::hash($componentName);
             $slotsVariableName = '$__slots' . $hash;
@@ -175,7 +176,7 @@ class Compiler
             $output .= '<' . '?php ' . $slotsVariableName . ' = []; ?>' . "\n";
             $output .= $this->slotCompiler->compile($slotsVariableName, $node->children);
             $output .= '<' . '?php ' . $slotsVariableName . ' = array_merge($__blaze->mergedComponentSlots(), ' . $slotsVariableName . '); ?>' . "\n";
-            $output .= '<' . '?php ' . $functionName . '($__blaze, $attributes->all(), ' . $slotsVariableName . ', [], [], $__this ?? (isset($this) ? $this : null)); ?>' . "\n";
+            $output .= '<' . '?php ' . $functionName . '($__blaze, $__delegatedData, ' . $slotsVariableName . ', [], [], $__this ?? (isset($this) ? $this : null)); ?>' . "\n";
             $output .= '<' . '?php if (! empty(' . $slotsStackName . ')) { ' . $slotsVariableName . ' = array_pop(' . $slotsStackName . '); } ?>' . "\n";
         }
 
@@ -184,7 +185,7 @@ class Compiler
         $output .= '<' . '?php endif; ?>' . "\n";
 
         $output .= '<' . '?php $__blaze->popData(); ?>' . "\n";
-        $output .= '<' . '?php unset($__resolved) ?>';
+        $output .= '<' . '?php unset($__resolved, $__delegatedData) ?>';
 
         return $output;
     }

--- a/src/Runtime/BlazeRuntime.php
+++ b/src/Runtime/BlazeRuntime.php
@@ -134,6 +134,20 @@ class BlazeRuntime
     }
 
     /**
+    * Revert escaping of data passed through attributes.
+    */
+    public function unescapeAttributes($data): array
+    {
+        $result = [];
+
+        foreach ($data as $key => $value) {
+            $result[$key] = is_string($value) ? htmlspecialchars_decode($value, ENT_QUOTES) : $value;
+        }
+
+        return $result;
+    }
+
+    /**
      * Push component data onto the stack for @aware lookups.
      */
     public function pushData(array $data): void

--- a/tests/Compiler/CompilerTest.php
+++ b/tests/Compiler/CompilerTest.php
@@ -69,7 +69,7 @@ test('compiles delegate components', function () {
 
     expect($compiled->render())->toEqualCollapsingWhitespace(join('', [
         '<?php $__resolved = $__blaze->resolve(\'flux::\' . card); ?> ',
-        '<?php $__delegatedData = $__blaze->unescapeAttributes($attributes->all()); ?> ',
+        '<?php $__delegatedData = $__blaze->unescapeAttributes($attributes->getAttributes()); ?> ',
         '<?php $__blaze->pushData($__delegatedData); ?> ',
         '<?php if ($__resolved !== false): ?> ',
         '<?php (\'_\' . $__resolved)($__blaze, $__delegatedData, $__blaze->mergedComponentSlots(), [], [], $__this ?? (isset($this) ? $this : null)); ?> ',

--- a/tests/Compiler/CompilerTest.php
+++ b/tests/Compiler/CompilerTest.php
@@ -69,14 +69,15 @@ test('compiles delegate components', function () {
 
     expect($compiled->render())->toEqualCollapsingWhitespace(join('', [
         '<?php $__resolved = $__blaze->resolve(\'flux::\' . card); ?> ',
-        '<?php $__blaze->pushData($attributes->all()); ?> ',
+        '<?php $__delegatedData = $__blaze->unescapeAttributes($attributes->all()); ?> ',
+        '<?php $__blaze->pushData($__delegatedData); ?> ',
         '<?php if ($__resolved !== false): ?> ',
-        '<?php (\'_\' . $__resolved)($__blaze, $attributes->all(), $__blaze->mergedComponentSlots(), [], [], $__this ?? (isset($this) ? $this : null)); ?> ',
+        '<?php (\'_\' . $__resolved)($__blaze, $__delegatedData, $__blaze->mergedComponentSlots(), [], [], $__this ?? (isset($this) ? $this : null)); ?> ',
         '<?php else: ?> ',
         '<flux:delegate-component component="card" /> ',
         '<?php endif; ?> ',
         '<?php $__blaze->popData(); ?> ',
-        '<?php unset($__resolved) ?>',
+        '<?php unset($__resolved, $__delegatedData) ?>',
     ]));
 });
 

--- a/tests/FluxTest.php
+++ b/tests/FluxTest.php
@@ -68,3 +68,11 @@ test('select', fn () => compare(<<<'BLADE'
     </flux:select>
     BLADE
 ));
+
+/**
+ * Checks that bound attributes passed through delegate component aren't double escaped
+ */
+test('select with bound attribute with ampersand', fn () => compare(<<<'BLADE'
+    <flux:select :placeholder="'Fish & Chips'" />
+    BLADE
+));

--- a/tests/FluxTest.php
+++ b/tests/FluxTest.php
@@ -73,6 +73,6 @@ test('select', fn () => compare(<<<'BLADE'
  * Checks that bound attributes passed through delegate component aren't double escaped
  */
 test('select with bound attribute with ampersand', fn () => compare(<<<'BLADE'
-    <flux:select :placeholder="'Fish & Chips'" />
+    <flux:select :placeholder="'Country & Region'" />
     BLADE
 ));


### PR DESCRIPTION
# The scenario

Setting a bound property on a component that uses `<flux:delegate-component>` causes double escaping:

```blade
<flux:select :label="'Country & Region'">
```

renders the label as

```
Country &amp; Region
```

# The problem

When compiling the delegate component we pass the current component data using `$attributes`:

```php
<?php __3f7e096d528cdf($attributes->all(), ...) ?>
```

The problem is that Laravel (and Blaze respectively) escapes all bound attributes.

Because we're passing them through two component boundaries, they will become double escaped.

```blade
<flux:select :label="'Country & Region'">

<flux:delegate-component :label="'Country &amp; Region'">

Country &amp;amp; Region
```

# The solution

Unescape the attributes before passing them into delegate component:

```php
<?php __3f7e096d528cdf($__blaze->unescapeAttributes($attributes->all()), ...) ?>
```

Fixes #190 