### PR TITLE
Fix DirectiveNode inheritance

### DIFF
--- a/src/Parser/Nodes/DirectiveNode.php
+++ b/src/Parser/Nodes/DirectiveNode.php
@@ -2,7 +2,7 @@
 
 namespace Livewire\Blaze\Parser\Nodes;
 
-class DirectiveNode extends TextNode
+class DirectiveNode extends Node
 {
     public function __construct(
         public string $name,


### PR DESCRIPTION
`DirectiveNode` was incorrectly extending `TextNode`.

While this isn't causing any bugs today, there is no benefit over extending base `Node`. If the `content` property was accessed on the `DirectiveNode`, this would throw an error as the property was never initialized.

Fixes #198 