### PR TITLE
Fold: reach inherited @aware values through the data stack

### DIFF
--- a/src/BladeRenderer.php
+++ b/src/BladeRenderer.php
@@ -39,7 +39,7 @@ class BladeRenderer
     /**
      * Render a Blade template string in isolation by freezing and restoring compiler state.
      */
-    public function render(ComponentNode $component, ComponentSource $source): string
+    public function render(ComponentNode $component, ComponentSource $source, array $aware = []): string
     {
         $temporaryCachePath = $this->getTemporaryCachePath();
 
@@ -112,6 +112,15 @@ class BladeRenderer
                 return [$slot->name => new ComponentSlot($slot->content())];
             });
 
+            $awareData = Arr::mapWithKeys($aware, function (Attribute $attribute) {
+                return [$attribute->name => $attribute->getStaticValue()];
+            });
+
+            // Inherited @aware values reach the component the way they do at render --
+            // through the data stack, under the component's own frame -- rather than by
+            // being merged into its attribute bag. A component that asks whether a key
+            // was written on its tag then gets the same answer folded and unfolded.
+            $this->runtime->pushData($awareData);
             $this->runtime->pushData($attributes);
             $this->runtime->pushSlots($slots);
 
@@ -131,6 +140,7 @@ class BladeRenderer
                 ob_end_clean();
             }
 
+            $this->runtime->popData();
             $this->runtime->popData();
             $this->manager->stopFolding();
 

--- a/src/Folder/Foldable.php
+++ b/src/Folder/Foldable.php
@@ -23,6 +23,9 @@ class Foldable
     protected array $slotByPlaceholder = [];
     protected int $placeholderIndex = 0;
 
+    /** @var array<string, Attribute> Inherited @aware values, kept out of the component's own bag. */
+    protected array $awareAttributes = [];
+
     protected ComponentNode $renderable;
     protected string $html;
 
@@ -52,7 +55,7 @@ class Foldable
         $this->setupSlots();
         $this->mergeAwareProps();
 
-        $this->html = $this->renderer->render($this->renderable, $this->source);
+        $this->html = $this->renderer->render($this->renderable, $this->source, $this->awareAttributes);
         
         $this->processUncompiledAttributes();
         $this->restorePlaceholders();
@@ -165,14 +168,14 @@ class Foldable
 
                     $this->attributeByPlaceholder[$placeholder] = $attribute;
 
-                    $this->renderable->attributes[$prop] = new Attribute(
+                    $this->awareAttributes[$prop] = new Attribute(
                         name: $prop,
                         value: $placeholder,
                         propName: $prop,
                         dynamic: false,
                     );
                 } else {
-                    $this->renderable->attributes[$prop] = new Attribute(
+                    $this->awareAttributes[$prop] = new Attribute(
                         name: $attribute->name,
                         value: $attribute->value,
                         propName: $attribute->propName,
@@ -187,7 +190,7 @@ class Foldable
                 // skip adding the attribute. This lets @aware and @props handle defaults
                 // at runtime, matching the non-folded behavior. Adding an attribute with
                 // null value would render as prop="" in HTML, corrupting null to empty string.
-                $this->renderable->attributes[$prop] = new Attribute(
+                $this->awareAttributes[$prop] = new Attribute(
                     name: $prop,
                     value: $default,
                     propName: $prop,

--- a/tests/ComparisonTest.php
+++ b/tests/ComparisonTest.php
@@ -52,6 +52,20 @@ test('foldable aware default', fn () => compare(<<<'BLADE'
     BLADE
 ));
 
+test('foldable aware read back off the attribute bag', fn () => compare(<<<'BLADE'
+    <x-foldable.wrapper type="number">
+        <x-foldable.input-aware-bag />
+    </x-foldable.wrapper>
+    BLADE
+));
+
+test('foldable aware written on the tag itself', fn () => compare(<<<'BLADE'
+    <x-foldable.wrapper type="number">
+        <x-foldable.input-aware-bag type="email" />
+    </x-foldable.wrapper>
+    BLADE
+));
+
 test('foldable boolean attributes', fn () => compare(<<<'BLADE'
     <x-foldable.input :readonly="$readonly" />
     BLADE,

--- a/tests/fixtures/views/components/foldable/input-aware-bag.blade.php
+++ b/tests/fixtures/views/components/foldable/input-aware-bag.blade.php
@@ -1,0 +1,18 @@
+@blaze(fold: true)
+
+{{-- A component that has to tell an attribute written on its own tag from one it
+     inherited. The field name on a form control is the usual case: it decides
+     whether the control owns its own validation message or whether the field
+     around it does. The bag is snapshotted and restored because @aware consumes
+     the key, and the value still has to reach the element. --}}
+@php
+    $__bag = $attributes->getAttributes();
+@endphp
+
+@aware(['type' => 'text'])
+
+@php
+    $attributes->setAttributes($__bag);
+@endphp
+
+<input type="{{ $type }}" data-source="{{ $attributes->get('type') === null ? 'inherited' : 'own' }}" >


### PR DESCRIPTION
Folding a component that declares `@aware` merges the inherited value into that component's **own attribute bag**. At render time the value never goes there — it reaches the component through the data stack, and the bag holds only what the call site wrote.

For most components that difference is invisible: both routes hand back the same value. It matters for a component that asks *where* a value came from rather than what it is.

### The case that surfaced it

A form control that inherits its field name from a wrapper, and uses "was this written on my tag?" to decide whether it owns its own validation message:

```blade
<x-field name="tags">
    <x-checkbox value="php" label="PHP" />
    <x-checkbox value="laravel" label="Laravel" />
</x-field>
```

Unfolded, the checkbox's bag has no `name`, so it can tell it is one of a group and leaves the message to the field. Folded, `name="tags"` is merged into its bag, it reads as a control that named itself, and the group's message is drawn again under **every** box. A `wire:model` control picks up a `name` attribute its binding meant to replace in the same way.

Neither shows up as broken markup — it is well formed, it just says something else. `@aware` unsetting the key afterwards doesn't help a component that has to snapshot and restore the bag around the directive, which is what a control does when the value also has to reach the rendered element.

### The change

`mergeAwareProps()` already knows the answer — it merges only where the call site did not write the key:

```php
if (isset($this->renderable->attributes[$prop])) {
    continue;
}
```

…and then discards it. This keeps those values in a frame of their own and pushes it *under* the component's, so `@aware` resolves in the order it does at render — own first, then ancestors — while the bag stays clean.

### Tests

Two cases added to `ComparisonTest`, which renders the same template through both pipelines and asserts byte equality.

The first fails on `main` and passes here:

```
- <input type="number" data-source="own" >
+ <input type="number" data-source="inherited" >
```

The second covers the other direction, so a value genuinely written on the tag is still read as the component's own. The existing suite is unchanged: 266 passing before, 268 after.

### Note

`InvalidBlazeFoldUsageException::forAware()` is defined and never called. With this, `@aware` and `fold` compose rather than being something to warn about — happy to wire the exception up instead if you'd rather go the other way, but this seemed the better end of it.