### PR TITLE
Fix aware mutating attribute bag

### DIFF
--- a/src/BladeRenderer.php
+++ b/src/BladeRenderer.php
@@ -39,7 +39,7 @@ class BladeRenderer
     /**
      * Render a Blade template string in isolation by freezing and restoring compiler state.
      */
-    public function render(ComponentNode $component, ComponentSource $source): string
+    public function render(ComponentNode $component, string $path): string
     {
         $temporaryCachePath = $this->getTemporaryCachePath();
 
@@ -93,16 +93,20 @@ class BladeRenderer
         ]);
 
         $obLevel = ob_get_level();
-        $hash = Utils::hash($source->path);
-        $path = $temporaryCachePath . '/' . $hash . '.php';
+        $hash = Utils::hash($path);
+        $compiled = $temporaryCachePath . '/' . $hash . '.php';
         $fn = '__' . $hash;
 
         $this->manager->startFolding();
 
         try {
-            if (! file_exists($path)) {
-                $this->blade->compile($source->path);
+            if (! file_exists($compiled)) {
+                $this->blade->compile($path);
             }
+
+            $awareData = Arr::mapWithKeys($component->parentsAttributes, function (Attribute $attribute) {
+                return [$attribute->name => $attribute->getStaticValue()];
+            });
 
             $attributes = Arr::mapWithKeys($component->attributes, function (Attribute $attribute) {
                 return [$attribute->name => $attribute->getStaticValue()];
@@ -112,12 +116,13 @@ class BladeRenderer
                 return [$slot->name => new ComponentSlot($slot->content())];
             });
 
+            $this->runtime->pushData($awareData);
             $this->runtime->pushData($attributes);
             $this->runtime->pushSlots($slots);
 
             ob_start();
 
-            require_once $path;
+            require_once $compiled;
 
             $fn(
                 __blaze: $this->runtime,
@@ -131,6 +136,7 @@ class BladeRenderer
                 ob_end_clean();
             }
 
+            $this->runtime->popData();
             $this->runtime->popData();
             $this->manager->stopFolding();
 

--- a/src/Compiler/AwareCompiler.php
+++ b/src/Compiler/AwareCompiler.php
@@ -40,12 +40,6 @@ class AwareCompiler
                 ? sprintf('$%s = $__blaze->getConsumableData(\'%s\', $__awareDefaults[\'%s\']);', $name, $name, $name)
                 : sprintf('$%s = $__blaze->getConsumableData(\'%s\');', $name, $name);
 
-            $kebab = Str::kebab($name);
-
-            $output .= $kebab !== $name
-                ? sprintf(' unset($attributes[\'%s\'], $attributes[\'%s\']);', $name, $kebab)
-                : sprintf(' unset($attributes[\'%s\']);', $name);
-
             $output .= "\n";
         }
 

--- a/src/Folder/Foldable.php
+++ b/src/Folder/Foldable.php
@@ -88,9 +88,7 @@ class Foldable
             name: $attribute->name,
             value: $placeholder,
             propName: $attribute->propName,
-            prefix: '',
             dynamic: false,
-            quotes: '"',
         );
     }
 

--- a/src/Folder/Foldable.php
+++ b/src/Folder/Foldable.php
@@ -28,7 +28,7 @@ class Foldable
 
     public function __construct(
         protected ComponentNode $node,
-        protected ComponentSource $source,
+        protected string $path,
         protected BladeRenderer $renderer,
         protected BladeService $blade,
     ) {
@@ -42,17 +42,13 @@ class Foldable
         $this->renderable = new ComponentNode(
             name: $this->node->name,
             prefix: $this->node->prefix,
-            attributeString: '',
-            children: [],
             selfClosing: $this->node->selfClosing,
-            parentsAttributes: $this->node->parentsAttributes,
         );
 
         $this->setupAttributes();
         $this->setupSlots();
-        $this->mergeAwareProps();
 
-        $this->html = $this->renderer->render($this->renderable, $this->source);
+        $this->html = $this->renderer->render($this->renderable, $this->path);
         
         $this->processUncompiledAttributes();
         $this->restorePlaceholders();
@@ -62,28 +58,40 @@ class Foldable
     }
 
     /**
-     * Replace dynamic attributes with placeholders, keep static ones as-is.
+     * Prepare component and inherited attributes for isolated rendering.
      */
     protected function setupAttributes(): void
     {
         foreach ($this->node->attributes as $key => $attribute) {
-            if (! $attribute->isStaticValue()) {
-                $placeholder = 'BLAZE_PLACEHOLDER_' . $this->placeholderIndex++ . '_';
-
-                $this->attributeByPlaceholder[$placeholder] = $attribute;
-
-                $this->renderable->attributes[$key] = new Attribute(
-                    name: $attribute->name,
-                    value: $placeholder,
-                    propName: $attribute->propName,
-                    prefix: '',
-                    dynamic: false,
-                    quotes: '"',
-                );
-            } else {
-                $this->renderable->attributes[$key] = clone $attribute;
-            }
+            $this->renderable->attributes[$key] = $this->prepareAttribute($attribute);
         }
+
+        foreach ($this->node->parentsAttributes as $key => $attribute) {
+            $this->renderable->parentsAttributes[$key] = $this->prepareAttribute($attribute);
+        }
+    }
+
+    /**
+     * Replace a dynamic attribute with a static placeholder for isolated rendering.
+     */
+    protected function prepareAttribute(Attribute $attribute): Attribute
+    {
+        if ($attribute->isStaticValue()) {
+            return clone $attribute;
+        }
+
+        $placeholder = 'BLAZE_PLACEHOLDER_' . $this->placeholderIndex++ . '_';
+
+        $this->attributeByPlaceholder[$placeholder] = $attribute;
+
+        return new Attribute(
+            name: $attribute->name,
+            value: $placeholder,
+            propName: $attribute->propName,
+            prefix: '',
+            dynamic: false,
+            quotes: '"',
+        );
     }
 
     /**
@@ -138,63 +146,6 @@ class Foldable
         }
 
         $this->renderable->children = $slots;
-    }
-
-    /**
-     * Merge @aware-declared props from parent attributes into the renderable node.
-     */
-    protected function mergeAwareProps(): void
-    {
-        $aware = $this->source->directives->array('aware') ?? [];
-        
-        foreach ($aware as $prop => $default) {
-            if (is_int($prop)) {
-                $prop = $default;
-                $default = null;
-            }
-
-            if (isset($this->renderable->attributes[$prop])) {
-                continue;
-            }
-            
-            if (isset($this->node->parentsAttributes[$prop])) {
-                $attribute = $this->node->parentsAttributes[$prop];
-
-                if (! $attribute->isStaticValue()) {
-                    $placeholder = 'BLAZE_PLACEHOLDER_' . $this->placeholderIndex++ . '_';
-
-                    $this->attributeByPlaceholder[$placeholder] = $attribute;
-
-                    $this->renderable->attributes[$prop] = new Attribute(
-                        name: $prop,
-                        value: $placeholder,
-                        propName: $prop,
-                        dynamic: false,
-                    );
-                } else {
-                    $this->renderable->attributes[$prop] = new Attribute(
-                        name: $attribute->name,
-                        value: $attribute->value,
-                        propName: $attribute->propName,
-                        dynamic: $attribute->dynamic,
-                        quotes: $attribute->quotes,
-                        prefix: $attribute->prefix,
-                    );
-                }
-            } else if ($default !== null) {
-                // TODO: test this, we might not need to add the default attributes because they will be added inside the component?
-                // When the value is null and no parent provides a value, we intentionally
-                // skip adding the attribute. This lets @aware and @props handle defaults
-                // at runtime, matching the non-folded behavior. Adding an attribute with
-                // null value would render as prop="" in HTML, corrupting null to empty string.
-                $this->renderable->attributes[$prop] = new Attribute(
-                    name: $prop,
-                    value: $default,
-                    propName: $prop,
-                    dynamic: false,
-                );
-            }
-        }
     }
 
     /**

--- a/src/Folder/Folder.php
+++ b/src/Folder/Folder.php
@@ -60,7 +60,7 @@ class Folder
         $this->checkProblematicPatterns($source);
 
         try {
-            $foldable = new Foldable($node, $source, $this->renderer, $this->blade);
+            $foldable = new Foldable($node, $source->path, $this->renderer, $this->blade);
 
             $html = $foldable->fold();
 

--- a/src/Folder/Folder.php
+++ b/src/Folder/Folder.php
@@ -103,9 +103,7 @@ class Folder
             return false;
         }
 
-        if (isset($node->parentsAttributes['attributes'])
-            && ! $node->parentsAttributes['attributes']->isStaticValue()
-        ) {
+        if (array_key_exists('attributes', $node->parentsAttributes)) {
             return false;
         }
 

--- a/src/Folder/Folder.php
+++ b/src/Folder/Folder.php
@@ -103,6 +103,12 @@ class Folder
             return false;
         }
 
+        if (isset($node->parentsAttributes['attributes'])
+            && ! $node->parentsAttributes['attributes']->isStaticValue()
+        ) {
+            return false;
+        }
+
         $dynamicAttributes = array_filter($node->attributes, fn ($attribute) => ! $attribute->isStaticValue());
 
         foreach ($source->directives->aware() as $prop) {

--- a/tests/BladeRendererTest.php
+++ b/tests/BladeRendererTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Livewire\Blaze\BladeRenderer;
+use Livewire\Blaze\Parser\Parser;
+use Livewire\Blaze\Support\AttributeParser;
+use Livewire\Blaze\Support\Utils;
+
+afterEach(fn () => app(BladeRenderer::class)->deleteTemporaryCacheDirectory());
+
+test('compiles component source into the temporary cache', function () {
+    $path = fixture_path('views/components/foldable/input.blade.php');
+    $node = app(Parser::class)->parse('<x-foldable.input />')[0];
+
+    app(BladeRenderer::class)->render($node, $path);
+
+    expect(File::exists(config('view.compiled').'/blaze/'.Utils::hash($path).'.php'))->toBeTrue();
+});
+
+test('makes attributes available to aware props', function () {
+    $node = app(Parser::class)->parse('<x-foldable.input-aware type="number" />')[0];
+
+    $output = app(BladeRenderer::class)->render($node, fixture_path('views/components/foldable/input-aware.blade.php'));
+
+    expect($output)->toEqualCollapsingWhitespace('<input type="number" >');
+});
+
+test('makes slots available to aware props', function () {
+    $node = app(Parser::class)->parse('<x-foldable.input-aware><x-slot:type>number</x-slot:type></x-foldable.input-aware>')[0];
+
+    $output = app(BladeRenderer::class)->render($node, fixture_path('views/components/foldable/input-aware.blade.php'));
+
+    expect($output)->toEqualCollapsingWhitespace('<input type="number" >');
+});
+
+test('makes parents attributes available to aware props', function () {
+    $node = app(Parser::class)->parse('<x-foldable.input-aware />')[0];
+
+    $node->setParentsAttributes(
+        app(AttributeParser::class)->parse('type="number"')
+    );
+
+    $output = app(BladeRenderer::class)->render($node, fixture_path('views/components/foldable/input-aware.blade.php'));
+
+    expect($output)->toEqualCollapsingWhitespace('<input type="number" >');
+});
+
+test('processes unblaze blocks', function () {
+    $node = app(Parser::class)->parse('<x-foldable.input-unblaze name="address" />')[0];
+
+    $output = app(BladeRenderer::class)->render($node, fixture_path('views/components/foldable/input-unblaze.blade.php'));
+
+    expect($output)->toEqualCollapsingWhitespace(sprintf('<input %s >', join('', [
+        '<?php if (isset($scope)) $__scope = $scope; ?>',
+        '<?php $scope = array ( \'name\' => \'address\', ); ?>',
+        ' {{ $errors->has($scope[\'name\']) }} ',
+        '<?php if (isset($__scope)) { $scope = $__scope; unset($__scope); } ?>',
+    ])));
+});
+
+test('deletes the temporary cache directory', function () {
+    $node = app(Parser::class)->parse('<x-foldable.input />')[0];
+
+    app(BladeRenderer::class)->render($node, fixture_path('views/components/foldable/input.blade.php'));
+
+    expect(File::isDirectory(config('view.compiled').'/blaze'))->toBeTrue();
+
+    app(BladeRenderer::class)->deleteTemporaryCacheDirectory();
+
+    expect(File::isDirectory(config('view.compiled').'/blaze'))->toBeFalse();
+});

--- a/tests/ComparisonTest.php
+++ b/tests/ComparisonTest.php
@@ -150,3 +150,9 @@ test('foldable conditional slots', fn () => compare(<<<'BLADE'
     </x-foldable.card>
     BLADE
 ));
+
+
+test('foldable aware without props', fn () => compare(<<<'BLADE'
+    <x-foldable.input-aware-no-props type="number" />
+    BLADE
+));

--- a/tests/ComparisonTest.php
+++ b/tests/ComparisonTest.php
@@ -151,7 +151,6 @@ test('foldable conditional slots', fn () => compare(<<<'BLADE'
     BLADE
 ));
 
-
 test('foldable aware without props', fn () => compare(<<<'BLADE'
     <x-foldable.input-aware-no-props type="number" />
     BLADE

--- a/tests/Compiler/WrapperTest.php
+++ b/tests/Compiler/WrapperTest.php
@@ -49,7 +49,7 @@ test('compiles aware props', function () {
         'ob_start(); ?> ',
         '@blaze ',
         '<?php $__awareDefaults = [\'type\' => \'text\']; ',
-        '$type = $__blaze->getConsumableData(\'type\', $__awareDefaults[\'type\']); unset($attributes[\'type\']); ',
+        '$type = $__blaze->getConsumableData(\'type\', $__awareDefaults[\'type\']); ',
         'unset($__awareDefaults); ?> ',
         '<?php $__defaults = [\'type\' => \'text\', \'disabled\' => false]; ',
         '$type ??= $attributes[\'type\'] ?? $__defaults[\'type\']; unset($attributes[\'type\']); ',

--- a/tests/Folder/FoldableTest.php
+++ b/tests/Folder/FoldableTest.php
@@ -1,29 +1,210 @@
 <?php
 
-use Illuminate\Support\Facades\Artisan;
 use Livewire\Blaze\BladeRenderer;
 use Livewire\Blaze\BladeService;
 use Livewire\Blaze\Folder\Foldable;
-use Livewire\Blaze\Parser\Attribute;
+use Livewire\Blaze\Parser\Nodes\ComponentNode;
 use Livewire\Blaze\Parser\Parser;
-use Livewire\Blaze\Support\ComponentSource;
+use Livewire\Blaze\Support\AttributeParser;
 
-beforeEach(fn () => Artisan::call('view:clear'));
+use function Pest\Laravel\mock;
 
-test('folds dynamic attributes', function () {
-    $input = '<x-foldable.input :type="$type" />';
+test('replaces and restores bound attributes', function () {
+    $node = app(Parser::class)->parse('<x-input :type="$type" />')[0];
 
-    $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input.blade.php')), app(BladeRenderer::class), app(BladeService::class));
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-input type="BLAZE_PLACEHOLDER_0_" />');
 
-    expect($foldable->fold())->toEqualCollapsingWhitespace(
-        '<input type="{{ $type }}" >'
+            return true;
+        })
+        ->andReturn('<input type="BLAZE_PLACEHOLDER_0_" >');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toEqualCollapsingWhitespace('<input type="{{ $type }}" >');
+});
+
+test('preserves bound attributes with static constant values', function (string $value) {
+    $node = app(Parser::class)->parse('<x-input :disabled="' . $value . '" />')[0];
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) use ($value) {
+            expect($node->render())->toBe('<x-input :disabled="' . $value . '" />');
+
+            return true;
+        })
+        ->andReturn('');
+
+    (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+})->with(['false', 'true', 'null']);
+
+test('replaces parents attributes', function () {
+    $node = app(Parser::class)->parse('<x-input />')[0];
+
+    $node->setParentsAttributes(
+        app(AttributeParser::class)->parse(':type="$type"')
+    );
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-input />');
+            expect($node->parentsAttributes['type']->render())->toBe('type="BLAZE_PLACEHOLDER_0_"');
+
+            return true;
+        })
+        ->andReturn('<input type="BLAZE_PLACEHOLDER_0_">');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toEqualCollapsingWhitespace('<input type="{{ $type }}">');
+});
+
+test('restores every occurrence of a dynamic attribute placeholder', function () {
+    $node = app(Parser::class)->parse('<x-button wire:click="save({{ $id }})" />')[0];
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-button wire:click="BLAZE_PLACEHOLDER_0_" />');
+
+            return true;
+        })
+        ->andReturn('<button wire:target="BLAZE_PLACEHOLDER_0_" wire:click="BLAZE_PLACEHOLDER_0_"></button>');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toEqualCollapsingWhitespace(
+        '<button wire:target="save({{ $id }})" wire:click="save({{ $id }})"></button>'
     );
 });
 
-test('folds slots', function () {
+test('restores bound attributes inside php blocks as raw expressions', function () {
+    $node = app(Parser::class)->parse('<x-input :type="$type" />')[0];
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-input type="BLAZE_PLACEHOLDER_0_" />');
+
+            return true;
+        })
+        ->andReturn("<?php echo strtoupper('BLAZE_PLACEHOLDER_0_'); ?>");
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toBe('<?php echo strtoupper($type); ?>');
+});
+
+test('compiles echo attributes restored inside php blocks', function () {
+    $node = app(Parser::class)->parse('<x-layout theme="dark-{{ $variant }}" />')[0];
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-layout theme="BLAZE_PLACEHOLDER_0_" />');
+
+            return true;
+        })
+        ->andReturn("<?php echo 'BLAZE_PLACEHOLDER_0_'; ?>");
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toBe("<?php echo 'dark-'.e(\$variant); ?>");
+});
+
+test('compiles bound attributes passed through attribute bag', function () {
+    $node = app(Parser::class)->parse('<x-input :required="$required" />')[0];
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-input required="BLAZE_PLACEHOLDER_0_" />');
+
+            return true;
+        })
+        ->andReturn('<input [BLAZE_ATTR:BLAZE_PLACEHOLDER_0_:required] type="text" >');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toEqualCollapsingWhitespace(
+        sprintf('<input %s type="text" >', join('', [
+            '<?php if (($__blazeAttr = $required) !== false && !is_null($__blazeAttr)): ?>',
+            'required="<?php echo e($__blazeAttr === true ? \'required\' : $__blazeAttr); ?>"',
+            '<?php endif; unset($__blazeAttr); ?>',
+        ]))
+    );
+});
+
+test('restores unbound attributes passed through attribute bag', function () {
+    $node = app(Parser::class)->parse('<x-button wire:click="save({{ $id }})" />')[0];
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-button wire:click="BLAZE_PLACEHOLDER_0_" />');
+
+            return true;
+        })
+        ->andReturn('<button [BLAZE_ATTR:BLAZE_PLACEHOLDER_0_:wire:click]></button>');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toBe('<button wire:click="save({{ $id }})"></button>');
+});
+
+test('uses empty strings for true x-data and wire: attributes passed through attribute bag', function (string $attribute) {
+    $node = app(Parser::class)->parse('<x-input :'.$attribute.'="$value" />')[0];
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) use ($attribute) {
+            expect($node->render())->toBe('<x-input '.$attribute.'="BLAZE_PLACEHOLDER_0_" />');
+
+            return true;
+        })
+        ->andReturn('<input [BLAZE_ATTR:BLAZE_PLACEHOLDER_0_:'.$attribute.']>');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toBe(implode('', [
+        '<input ',
+        '<?php if (($__blazeAttr = $value) !== false && !is_null($__blazeAttr)): ?>',
+        $attribute.'="<?php echo e($__blazeAttr === true ? \'\' : $__blazeAttr); ?>"',
+        '<?php endif; unset($__blazeAttr); ?>',
+        '>',
+    ]));
+})->with(['x-data', 'wire:loading']);
+
+test('handles newlines consumed by attribute php blocks', function () {
+    $node = app(Parser::class)->parse('<x-input :required="$required" />')[0];
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-input required="BLAZE_PLACEHOLDER_0_" />');
+
+            return true;
+        })
+        ->andReturn("<input\n[BLAZE_ATTR:BLAZE_PLACEHOLDER_0_:required]\n>");
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toBe(implode('', [
+        "<input\n",
+        '<?php if (($__blazeAttr = $required) !== false && !is_null($__blazeAttr)): ?>',
+        'required="<?php echo e($__blazeAttr === true ? \'required\' : $__blazeAttr); ?>"',
+        '<?php endif; unset($__blazeAttr); ?>',
+        "\n\n>",
+    ]));
+});
+
+test('restores named and default slots after rendering', function () {
     $input = <<<'BLADE'
-        <x-foldable.card>
+        <x-card>
             Before
             <x-slot:header>
                 {{ $title }}
@@ -34,13 +215,38 @@ test('folds slots', function () {
             </x-slot:footer>
             After
         </x-card>
-        BLADE
-    ;
+        BLADE;
 
     $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/card.blade.php')), app(BladeRenderer::class), app(BladeService::class));
 
-    expect($foldable->fold())->toEqualCollapsingWhitespace(<<<'HTML'
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe(join('', [
+                '<x-card>',
+                    '<x-slot:header>BLAZE_PLACEHOLDER_0_</x-slot:header>',
+                    '<x-slot:footer>BLAZE_PLACEHOLDER_1_</x-slot:footer>',
+                    '<x-slot name="slot">BLAZE_PLACEHOLDER_2_</x-slot>',
+                '</x-card>',
+                ])
+            );
+
+            return true;
+        })
+        ->andReturn(<<<'HTML'
+            <div>
+                BLAZE_PLACEHOLDER_0_
+                <hr>
+                BLAZE_PLACEHOLDER_2_
+                <hr>
+                BLAZE_PLACEHOLDER_1_
+            </div>
+            HTML
+        );
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toEqualCollapsingWhitespace(<<<'HTML'
         <div>
             <?php ob_start(); ?> {{ $title }} <?php echo trim(ob_get_clean()); ?>
             <hr>
@@ -52,135 +258,147 @@ test('folds slots', function () {
     );
 });
 
-test('preserves dynamic attributes with static false', function () {
-    $input = '<x-foldable.input :disabled="false" />';
+test('does not synthesize a default slot when one is explicit', function () {
+    $input = <<<'BLADE'
+        <x-card>
+            Ignored loose content
+            <x-slot name="slot">Explicit content</x-slot>
+        </x-card>
+        BLADE;
 
     $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input.blade.php')), app(BladeRenderer::class), app(BladeService::class));
 
-    expect($foldable->fold())->toEqualCollapsingWhitespace(
-        '<input type="text" >'
-    );
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-card><x-slot name="slot">BLAZE_PLACEHOLDER_0_</x-slot></x-card>');
+
+            return true;
+        })
+        ->andReturn('<div>BLAZE_PLACEHOLDER_0_</div>');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toBe('<div><?php ob_start(); ?>Explicit content<?php echo trim(ob_get_clean()); ?></div>');
 });
 
-test('preserves dynamic attributes with static null', function () {
-    $input = '<x-foldable.input :disabled="null" />';
+test('handles newlines consumed by slot php blocks', function () {
+    $node = app(Parser::class)->parse('<x-card>Content</x-card>')[0];
 
-    $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input.blade.php')), app(BladeRenderer::class), app(BladeService::class));
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-card><x-slot name="slot">BLAZE_PLACEHOLDER_0_</x-slot></x-card>');
 
-    expect($foldable->fold())->toEqualCollapsingWhitespace(
-        '<input type="text" >'
-    );
-});
+            return true;
+        })
+        ->andReturn("<div>BLAZE_PLACEHOLDER_0_\n</div>");
 
-test('merges aware props from parent attributes', function () {
-    $input = '<x-foldable.input-aware />';
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
 
-    $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input-aware.blade.php')), app(BladeRenderer::class), app(BladeService::class));
-
-    $node->setParentsAttributes([
-        'type' => new Attribute(
-            name: 'type',
-            value: 'number',
-            propName: 'type',
-            dynamic: false
-        ),
-    ]);
-
-    expect($foldable->fold())->toEqualCollapsingWhitespace(
-        '<input type="number" >'
-    );
-});
-
-test('merges dynamic aware props from parent attributes', function () {
-    $input = '<x-foldable.input-aware />';
-
-    $node = app(Parser::class)->parse($input)[0];
-    $node->setParentsAttributes([
-        'type' => new Attribute(
-            name: 'type',
-            value: '$type',
-            propName: 'type',
-            dynamic: true,
-            prefix: ':',
-            quotes: '"',
-        ),
-    ]);
-
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input-aware.blade.php')), app(BladeRenderer::class), app(BladeService::class));
-
-    expect($foldable->fold())->toEqualCollapsingWhitespace(
-        '<input type="{{ $type }}" >'
-    );
-});
-
-test('folds dynamic attributes passed through attribute bag', function () {
-    $input = '<x-foldable.input :readonly="$readonly" />';
-
-    $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input.blade.php')), app(BladeRenderer::class), app(BladeService::class));
-
-    expect($foldable->fold())->toEqualCollapsingWhitespace(
-        sprintf('<input %s type="text" >', join('', [
-            '<?php if (($__blazeAttr = $readonly) !== false && !is_null($__blazeAttr)): ?>',
-            'readonly="<?php echo e($__blazeAttr === true ? \'readonly\' : $__blazeAttr); ?>"',
-            '<?php endif; unset($__blazeAttr); ?>',
-        ]))
-    );
-});
-
-test('folds dynamic attributes reused under a different key', function () {
-    $input = '<x-foldable.button wire:click="save({{ $id }})" />';
-    $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/button.blade.php')), app(BladeRenderer::class), app(BladeService::class));
-    expect($foldable->fold())->toEqualCollapsingWhitespace(
-        '<button wire:target="save({{ $id }})" wire:click="save({{ $id }})" type="button"></button>'
-    );
+    expect($output)->toBe("<div><?php ob_start(); ?>Content<?php echo trim(ob_get_clean()); ?>\n\n</div>");
 });
 
 test('wraps output with aware macros if descendants use aware', function () {
-    $input = '<x-foldable.wrapper name="John"><x-aware-descendant /></x-foldable.wrapper>';
+    $node = app(Parser::class)->parse('<x-layout theme="dark" />')[0];
 
-    $node = app(Parser::class)->parse($input)[0];
     $node->hasAwareDescendants = true;
 
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/wrapper.blade.php')), app(BladeRenderer::class), app(BladeService::class));
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-layout theme="dark" />');
 
-    expect($foldable->fold())->toEqualCollapsingWhitespace(join('', [
-        '<?php $__blaze->pushData([\'name\' => \'John\']); $__env->pushConsumableComponentData([\'name\' => \'John\']); ?>',
-        '<div> <?php ob_start(); ?><x-aware-descendant /><?php echo trim(ob_get_clean()); ?> </div>',
+            return true;
+        })
+        ->andReturn('<div></div>');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toEqualCollapsingWhitespace(join('', [
+        '<?php $__blaze->pushData([\'theme\' => \'dark\']); $__env->pushConsumableComponentData([\'theme\' => \'dark\']); ?>',
+        '<div></div>',
         '<?php $__blaze->popData(); $__env->popConsumableComponentData(); ?>',
     ]));
 });
 
 test('compiles dynamic attributes in aware macros', function () {
-    $input = '<x-foldable.wrapper :name="$name"><x-aware-descendant /></x-foldable.wrapper>';
+    $node = app(Parser::class)->parse('<x-layout :theme="$theme" />')[0];
 
-    $node = app(Parser::class)->parse($input)[0];
     $node->hasAwareDescendants = true;
 
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/wrapper.blade.php')), app(BladeRenderer::class), app(BladeService::class));
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-layout theme="BLAZE_PLACEHOLDER_0_" />');
 
-    expect($foldable->fold())->toEqualCollapsingWhitespace(join('', [
-        '<?php $__blaze->pushData([\'name\' => $name]); $__env->pushConsumableComponentData([\'name\' => $name]); ?>',
-        '<div> <?php ob_start(); ?><x-aware-descendant /><?php echo trim(ob_get_clean()); ?> </div>',
+            return true;
+        })
+        ->andReturn('<div></div>');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toEqualCollapsingWhitespace(join('', [
+        '<?php $__blaze->pushData([\'theme\' => $theme]); $__env->pushConsumableComponentData([\'theme\' => $theme]); ?>',
+        '<div></div>',
         '<?php $__blaze->popData(); $__env->popConsumableComponentData(); ?>',
     ]));
 });
 
 test('compiles echo attributes in aware macros', function () {
-    $input = '<x-foldable.wrapper name="Mr. {{ $name }}"><x-aware-descendant /></x-foldable.wrapper>';
-
-    $node = app(Parser::class)->parse($input)[0];
+    $node = app(Parser::class)->parse('<x-layout theme="dark-{{ $variant }}" />')[0];
     $node->hasAwareDescendants = true;
 
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/wrapper.blade.php')), app(BladeRenderer::class), app(BladeService::class));
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-layout theme="BLAZE_PLACEHOLDER_0_" />');
 
-    expect($foldable->fold())->toEqualCollapsingWhitespace(join('', [
-        '<?php $__blaze->pushData([\'name\' => \'Mr. \'.e($name)]); $__env->pushConsumableComponentData([\'name\' => \'Mr. \'.e($name)]); ?>',
-        '<div> <?php ob_start(); ?><x-aware-descendant /><?php echo trim(ob_get_clean()); ?> </div>',
+            return true;
+        })
+        ->andReturn('<div></div>');
+
+    $output = (new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold();
+
+    expect($output)->toEqualCollapsingWhitespace(join('', [
+        '<?php $__blaze->pushData([\'theme\' => \'dark-\'.e($variant)]); $__env->pushConsumableComponentData([\'theme\' => \'dark-\'.e($variant)]); ?>',
+        '<div></div>',
         '<?php $__blaze->popData(); $__env->popConsumableComponentData(); ?>',
     ]));
+});
+
+test('does not add aware macros to components without attributes', function () {
+    $node = app(Parser::class)->parse('<x-layout />')[0];
+    $node->hasAwareDescendants = true;
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-layout />');
+
+            return true;
+        })
+        ->andReturn('<div></div>');
+
+    expect((new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold())
+        ->toBe('<div></div>');
+});
+
+test('does not add aware macros for inherited attributes only', function () {
+    $node = app(Parser::class)->parse('<x-layout />')[0];
+    $node->hasAwareDescendants = true;
+    $node->setParentsAttributes(app(AttributeParser::class)->parse('theme="dark"'));
+
+    mock(BladeRenderer::class)
+        ->expects('render')
+        ->once()->withArgs(function (ComponentNode $node) {
+            expect($node->render())->toBe('<x-layout />');
+            expect($node->parentsAttributes['theme']->render())->toBe('theme="dark"');
+
+            return true;
+        })
+        ->andReturn('<div></div>');
+
+    expect((new Foldable($node, '', app(BladeRenderer::class), app(BladeService::class)))->fold())
+        ->toBe('<div></div>');
 });

--- a/tests/Folder/FolderTest.php
+++ b/tests/Folder/FolderTest.php
@@ -80,6 +80,20 @@ test('does not fold components with attribute spread', function () {
     expect($folded)->toBeInstanceOf(ComponentNode::class);
 });
 
+test('does not fold components with attribute spread from parent', function () {
+    $input = '<x-foldable.input />';
+
+    $node = app(Parser::class)->parse($input)[0];
+    
+    $node->setParentsAttributes(
+        app(AttributeParser::class)->parse(':attributes="$attributes"')
+    );
+
+    $folded = app(Folder::class)->fold($node);
+
+    expect($folded)->toBeInstanceOf(ComponentNode::class);
+});
+
 test('folds components with slots', function () {
     $input = '<x-foldable.card><x-slot:header>Header</x-slot:header>Body</x-foldable.card>';
     

--- a/tests/Folder/UnblazeTest.php
+++ b/tests/Folder/UnblazeTest.php
@@ -3,14 +3,13 @@
 use Livewire\Blaze\BladeRenderer;
 use Livewire\Blaze\BladeService;
 use Livewire\Blaze\Folder\Foldable;
-use Livewire\Blaze\Support\ComponentSource;
 use Livewire\Blaze\Parser\Parser;
 
 test('compiles unblaze blocks', function () {
     $input = '<x-foldable.input-unblaze name="address" />';
 
     $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input-unblaze.blade.php')), app(BladeRenderer::class), app(BladeService::class));
+    $foldable = new Foldable($node, fixture_path('views/components/foldable/input-unblaze.blade.php'), app(BladeRenderer::class), app(BladeService::class));
 
     expect($foldable->fold())->toEqualCollapsingWhitespace(
         sprintf('<input %s >', join('', [
@@ -26,7 +25,7 @@ test('compiles nested unblaze blocks', function () {
     $input = '<x-foldable.nested-input-unblaze />';
 
     $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/nested-input-unblaze.blade.php')), app(BladeRenderer::class), app(BladeService::class));
+    $foldable = new Foldable($node, fixture_path('views/components/foldable/nested-input-unblaze.blade.php'), app(BladeRenderer::class), app(BladeService::class));
 
     expect($foldable->fold())->toEqualCollapsingWhitespace(
         sprintf('<div> <input %s ></div>', join('', [
@@ -42,7 +41,7 @@ test('folds dynamic attributes used inside unblaze directive', function () {
     $input = '<x-foldable.input-unblaze :name="$field" />';
 
     $node = app(Parser::class)->parse($input)[0];
-    $foldable = new Foldable($node, new ComponentSource(fixture_path('views/components/foldable/input-unblaze.blade.php')), app(BladeRenderer::class), app(BladeService::class));
+    $foldable = new Foldable($node, fixture_path('views/components/foldable/input-unblaze.blade.php'), app(BladeRenderer::class), app(BladeService::class));
 
     expect($foldable->fold())->toEqualCollapsingWhitespace(
         sprintf('<input %s >', join('', [

--- a/tests/fixtures/views/components/foldable/input-aware-no-props.blade.php
+++ b/tests/fixtures/views/components/foldable/input-aware-no-props.blade.php
@@ -1,0 +1,8 @@
+@blaze(fold: true)
+
+@aware(['type'])
+
+{{-- We intentionally do not set @props here to ensure aware props are preserved in $attributes --}}
+{{-- When type="number" is passed, below should be rendered as <input type="number" type="number"> --}}
+
+<input {{ $attributes }} type="{{ $type }}" >

--- a/tests/fixtures/views/components/foldable/input-aware.blade.php
+++ b/tests/fixtures/views/components/foldable/input-aware.blade.php
@@ -1,5 +1,7 @@
 @blaze(fold: true)
 
-@aware(['type' => 'text'])
+@aware(['type'])
 
-<input type="{{ $type }}" >
+@props(['type' => 'text'])
+
+<input {{ $attributes }} type="{{ $type }}" >


### PR DESCRIPTION
## The scenario

Blaze removes attributes defined in `@aware` from the attribute bag.

```blade
{{-- resources/views/components/input.blade.php --}}

@aware(['type'])

<input {{ $attributes }}>
```

Rendering `<x-input type="number">` will produce:

* `<input type="number">` in Blade
* `<input >` in Blaze

_The component intentionally doesn't use `@props` to demonstrate the issue_

## The problem

When components are folded, they do not have access to the data stack which `@aware` uses. We compensate for that by appending parent attributes to the node during folding. For example, when folding `<x-input>` in the view below:

```blade
<x-wrapper type="number">
    <x-input> {{-- Uses @aware(['type']) --}}
</x-wrapper>
```

We take `type="number"` from the parent and add it to the node itself before rendering:

```blade
<x-input type="number">`
```

This provides the parent data to the component, however, it also adds `type` to the attribute bag. We then have to `unset($attributes['type'])` when compiling `@aware`, which causes the original issue.

This only affects a narrow use-case: if `@props` aren't used or if the attribute bag is accessed before `@aware` but it highlights a real divergence from Blade.

## The solution

Provide parent data via data stack and stop mutating the attribute bag from inside `@aware`.

```php
$awareData = Arr::map($renderable->parentAttributes, ...);
$attributes = Arr::map($renderable->attributes, ...);

$this->runtime->pushData($awareData);
$this->runtime->pushData($attributes);

require $compiled;

$this->runtime->popData();
$this->runtime->popData();
```

We've already had an isolated data stack, however we only pushed `$attributes` which only containes the data of the component that is currently rendered. Adding `$awareData` fixes the issue and the attribute bag can remain untouched.

This supersedes PR #200, which uncovered this issue.