### PR TITLE
Fix duplicate attribute precedence

### DIFF
--- a/src/Support/AttributeParser.php
+++ b/src/Support/AttributeParser.php
@@ -64,10 +64,6 @@ class AttributeParser
 
             $camelName = str()->camel($name);
 
-            if (isset($attributes[$camelName])) {
-                continue;
-            }
-
             $dynamic = $isDynamic || (is_string($value) && (str_contains($value, '{{') || str_contains($value, '{!!')));
 
             $attributes[$camelName] = new Attribute(

--- a/tests/ComparisonTest.php
+++ b/tests/ComparisonTest.php
@@ -160,3 +160,8 @@ test('foldable aware without props', fn () => compare(<<<'BLADE'
     <x-foldable.input-aware-no-props type="number" />
     BLADE
 ));
+
+test('duplicate attribute', fn () => compare(<<<'BLADE'
+    <x-input type="email" type="number" />
+    BLADE
+));

--- a/tests/Support/AttributeParserTest.php
+++ b/tests/Support/AttributeParserTest.php
@@ -72,9 +72,9 @@ test('parses kebab case attributes', function () {
         ->propName->toBe('fooBar');
 });
 
-test('keeps first attribute when multiple camelize to same key', function () {
+test('keeps last attribute when multiple camelize to same key', function () {
     $attrs = app(AttributeParser::class)->parse('foo-bar="first" foo_bar="second"');
 
     expect($attrs)->toHaveCount(1)->toHaveKey('fooBar');
-    expect($attrs['fooBar']->value)->toBe('first');
+    expect($attrs['fooBar']->value)->toBe('second');
 });


### PR DESCRIPTION
## The scenario

Blaze handles duplicate attributes incorrectly:

```blade
<x-input label="Filip" label="Ganyicz" />
```

* Blade: `label: Ganyicz`
* Blaze: `label: Filip`

## The problem

During attribute parsing, when a duplicate attribute is encountered it will be intentionally skipped:

```php
if (isset($attributes[$camelName])) {
    continue;
}
```

This makes Blaze follow **first wins** ordering, whereas Blade follows **last wins**.

## The solution

Let latter attributes override former ones