### PR TITLE
Recompile cache when timestamps are equal

### DIFF
--- a/src/BladeRenderer.php
+++ b/src/BladeRenderer.php
@@ -101,7 +101,7 @@ class BladeRenderer
         $this->manager->startFolding();
 
         try {
-            if (! file_exists($compiled) || filemtime($path) > filemtime($compiled)) {
+            if (! file_exists($compiled) || filemtime($path) >= filemtime($compiled)) {
                 $this->blade->compile($path);
             }
 

--- a/src/Runtime/BlazeRuntime.php
+++ b/src/Runtime/BlazeRuntime.php
@@ -49,7 +49,7 @@ class BlazeRuntime
      */
     public function compile(string $path, string $compiledPath): void
     {
-        if (! file_exists($compiledPath) || filemtime($path) > filemtime($compiledPath)) {
+        if (! file_exists($compiledPath) || filemtime($path) >= filemtime($compiledPath)) {
             $this->compiler->compile($path);
         }
     }

--- a/tests/BladeRendererTest.php
+++ b/tests/BladeRendererTest.php
@@ -99,3 +99,48 @@ test('recompiles stale cache of folded components', function () {
         File::deleteDirectory($dir);
     }
 });
+
+test('recompiles stale cache when source and compiled timestamps are equal', function () {
+    $dir = sys_get_temp_dir().'/blaze-'.uniqid();
+    $path = $dir.'/button.blade.php';
+
+    try {
+        File::ensureDirectoryExists($dir);
+        File::put($path, '@blaze(fold: true) stale');
+
+        $blaze = app(BlazeManager::class);
+        $renderer = app(BladeRenderer::class);
+        $blade = app(BladeCompiler::class);
+        $bladeCachePath = invade($blade)->cachePath;
+
+        // We can't use the renderer here because it would `require` the file
+        // and register a global function, which would produce stale output
+        // even after recompiling. So instead we'll simulate folding and
+        // we will only compile the file in the blaze cache directory
+        invade($blade)->cachePath = $renderer->getTemporaryCachePath();
+
+        $blaze->startFolding();
+        $blade->compile($path);
+        $blaze->stopFolding();
+
+        invade($blade)->cachePath = $bladeCachePath;
+
+        // Now change the source and give it the same timestamp as the compiled file
+        $compiled = $renderer->getTemporaryCachePath().'/'.Utils::hash($path).'.php';
+        $timestamp = now()->addSecond()->timestamp;
+
+        File::put($path, '@blaze(fold: true) fresh');
+
+        touch($path, $timestamp);
+        touch($compiled, $timestamp);
+        clearstatcache(true);
+
+        expect(File::lastModified($path))->toBe(File::lastModified($compiled));
+
+        $node = app(Parser::class)->parse('<x-button />')[0];
+
+        expect($renderer->render($node, $path))->toContain('fresh');
+    } finally {
+        File::deleteDirectory($dir);
+    }
+});

--- a/tests/Runtime/BlazeRuntimeTest.php
+++ b/tests/Runtime/BlazeRuntimeTest.php
@@ -1,6 +1,36 @@
 <?php
 
+use Illuminate\Support\Facades\File;
+use Illuminate\View\Compilers\BladeCompiler;
 use Livewire\Blaze\Runtime\BlazeRuntime;
+
+test('compiles stale cache when source and compiled timestamps are equal', function () {
+    $dir = sys_get_temp_dir().'/blaze-'.uniqid();
+    $path = $dir.'/button.blade.php';
+
+    try {
+        File::ensureDirectoryExists($dir);
+        File::put($path, 'fresh');
+
+        $compiled = app(BladeCompiler::class)->getCompiledPath($path);
+        $timestamp = now()->addSecond()->timestamp;
+
+        File::put($compiled, 'stale');
+
+        touch($path, $timestamp);
+        touch($compiled, $timestamp);
+        clearstatcache(true);
+
+        expect(File::lastModified($path))->toBe(File::lastModified($compiled));
+
+        app(BlazeRuntime::class)->compile($path, $compiled);
+
+        expect(File::get($compiled))->toContain('fresh');
+    } finally {
+        File::delete($compiled ?? '');
+        File::deleteDirectory($dir);
+    }
+});
 
 it('processPassthroughContent', function ($input, $results) {
     $input = str_replace('[UNBLAZE]', '[STARTCOMPILEDUNBLAZE:XXX][ENDCOMPILEDUNBLAZE:XXX]', $input);


### PR DESCRIPTION
## The scenario

When a component source changes within the same second its compiled cache was written, Blaze can render stale output.

## The problem

PHP file modification timestamps have one-second resolution, but the cache checks only consider a source stale when its modification time is greater than the compiled file:

```php
filemtime($path) > filemtime($compiled)
```

The sequence is:

1. Blaze compiles a component and writes its cache.
2. The component source changes within the same second.
3. The source and compiled file have equal modification times.
4. The comparison returns false and Blaze reuses the stale cache.

This affects both isolated rendering during folding and runtime component compilation.

## The solution

Treat equal timestamps as stale, matching Laravels cache expiration behavior:

```diff
- filemtime($path) > filemtime($compiled)
+ filemtime($path) >= filemtime($compiled)
```

Added regression tests for both cache paths.

Follow-up to #202